### PR TITLE
fix: accept standard Authorization: Bearer header

### DIFF
--- a/app/utils/api_validators.py
+++ b/app/utils/api_validators.py
@@ -1,15 +1,35 @@
 from datetime import datetime
+from typing import Optional
 
 from fastapi import HTTPException, Request, Security, status
 from fastapi.security.api_key import APIKeyHeader
 
 from app.utils.auth.auth_util import decrypt_jwt_token
 
-auth_jwt_header = APIKeyHeader(name="access_token", scheme_name="auth_token")
+# Accept both the standard Authorization: Bearer header and the legacy
+# custom access_token header for backward compatibility.
+auth_jwt_header = APIKeyHeader(name="access_token", scheme_name="auth_token", auto_error=False)
 
 
-async def verify_token(request: Request, auth_token: str = Security(auth_jwt_header)):
-    jwt_data = decrypt_jwt_token(auth_token)
+async def verify_token(
+    request: Request,
+    auth_token: Optional[str] = Security(auth_jwt_header),
+):
+    # Prefer standard Authorization: Bearer header; fall back to legacy access_token
+    token = None
+    auth_header = request.headers.get("authorization")
+    if auth_header and auth_header.lower().startswith("bearer "):
+        token = auth_header[7:]  # strip "Bearer "
+    if not token:
+        token = auth_token  # legacy access_token header
+
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication token",
+        )
+
+    jwt_data = decrypt_jwt_token(token)
 
     if jwt_data is None:
         raise HTTPException(


### PR DESCRIPTION
## Summary

Accept both the standard `Authorization: Bearer <token>` header and the legacy custom `access_token` header for backward compatibility.

## What changed

**`app/utils/api_validators.py`** — `verify_token()` now checks for `Authorization: Bearer` first, then falls back to the `access_token` header.

## Why

The server currently only accepts a custom `access_token` header for auth. This is non-standard — any developer or tool integrating with the API will default to `Authorization: Bearer` (the HTTP standard) and hit a wall. This was discovered during QA testing of the brainstorm-cli (see [nous-clawds4/brainstorm-cli#1](https://github.com/nous-clawds4/brainstorm-cli/pull/1)).

## Backward compatibility

- **Brainstorm-UI:** Continues working unchanged (still sends `access_token`)
- **New clients:** Can use `Authorization: Bearer <token>` as expected
- **No breaking changes**

## Ref
- nous-clawds4/brainstorm-cli#2
- QA report: https://github.com/nous-clawds4/brainstorm-cli/blob/main/QA-REPORT.md