### PR TITLE
fix: include_result=true no longer returns 500

### DIFF
--- a/app/repos/brainstorm_request_repo.py
+++ b/app/repos/brainstorm_request_repo.py
@@ -23,16 +23,17 @@ async def delete_brainstorm_request_by_id_on_db(
 
 
 async def select_brainstorm_request_by_id_and_password_on_db(
-    db: AsyncDBSession, brainstorm_request_id: int, brainstorm_request_password: str
+    db: AsyncDBSession,
+    brainstorm_request_id: int,
+    brainstorm_request_password: str,
+    include_result: bool = False,
 ) -> BrainstormRequest:
-    statement = (
-        select(BrainstormRequest)
-        .where(
-            BrainstormRequest.private_id == brainstorm_request_id,
-            BrainstormRequest.password == brainstorm_request_password,
-        )
-        .options(defer(BrainstormRequest.result))
+    statement = select(BrainstormRequest).where(
+        BrainstormRequest.private_id == brainstorm_request_id,
+        BrainstormRequest.password == brainstorm_request_password,
     )
+    if not include_result:
+        statement = statement.options(defer(BrainstormRequest.result))
     existing_data = await execute_db_statement(db, statement, __name__)
     result: BrainstormRequest | None = existing_data.scalars().first()
 

--- a/app/services/brainstorm_request_service.py
+++ b/app/services/brainstorm_request_service.py
@@ -51,6 +51,7 @@ async def get_brainstorm_request_by_id_and_password(
             db=db,
             brainstorm_request_id=brainstorm_request_id,
             brainstorm_request_password=brainstorm_request_password,
+            include_result=include_result,
         )
     )
 


### PR DESCRIPTION
## Problem

`GET /brainstormRequest/{id}?include_result=true` returns a 500 Internal Server Error. The `result` column is unconditionally deferred (lazy-loaded) at the repo layer, so when the service layer tries to access it after the session has closed, SQLAlchemy raises a `MissingGreenlet` / lazy-load error.

## Fix

Pass `include_result` through from the service layer to the repo query. Only apply `defer(BrainstormRequest.result)` when the caller does **not** request the result. When `include_result=true`, the column is eagerly loaded in the original query.

## Changes

- `app/repos/brainstorm_request_repo.py` — Add `include_result` parameter; conditionally defer the result column
- `app/services/brainstorm_request_service.py` — Forward `include_result` to the repo call