### PR TITLE
Optimise Profile page endpoints

### DIFF
--- a/app/repos/brainstorm_nsec.py
+++ b/app/repos/brainstorm_nsec.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from sqlalchemy import select, update
+from sqlalchemy.orm import defer
 from app.core.database import execute_db_statement, handle_no_data
 from app.db_models import BrainstormNsec
 from sqlalchemy.ext.asyncio import AsyncSession as AsyncDBSession
@@ -173,6 +174,32 @@ async def select_brainstorm_nsec_by_pubkey_on_db(
     db: AsyncDBSession, pubkey: str
 ) -> BrainstormNsec:
     statement = select(BrainstormNsec).where(BrainstormNsec.pubkey == pubkey)
+
+    existing_data = await execute_db_statement(db, statement, __name__)
+    result: BrainstormNsec | None = existing_data.scalars().first()
+
+    handle_no_data(result)
+    assert result
+
+    result.nsec = _resolve_plaintext_nsec(result)
+    return result
+
+
+async def select_brainstorm_nsec_history_fields_on_db(
+    db: AsyncDBSession, pubkey: str
+) -> BrainstormNsec:
+    # Skip large columns not needed by the user-history converter — most notably
+    # last_published_pubkeys (LargeBinary, can be 100s of KB) and graperank_custom_params (JSONB).
+    statement = (
+        select(BrainstormNsec)
+        .where(BrainstormNsec.pubkey == pubkey)
+        .options(
+            defer(BrainstormNsec.last_published_pubkeys),
+            defer(BrainstormNsec.last_published_graperank_request_id),
+            defer(BrainstormNsec.graperank_preset),
+            defer(BrainstormNsec.graperank_custom_params),
+        )
+    )
 
     existing_data = await execute_db_statement(db, statement, __name__)
     result: BrainstormNsec | None = existing_data.scalars().first()

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -246,16 +246,10 @@ async def get_paginated_section_connections(
     limit: int,
     cursor_inf: float | None,
     cursor_pk: str | None,
-    compute_stats: bool,
-    verified_threshold: float,
-    tier_high: float,
-    tier_trusted: float,
-    tier_neutral: float,
-) -> tuple[list[UserConnectionItem], ConnectionStats | None, tuple[float, str] | None]:
+) -> tuple[list[UserConnectionItem], tuple[float, str] | None]:
     """Cursor-paginated connection list ordered by (influence DESC, pubkey ASC).
-    On first page (no cursor), also returns ConnectionStats in a single query.
 
-    Returns (items, stats_or_none, last_record_cursor_or_none).
+    Returns (items, last_record_cursor_or_none).
     """
     scoped_pattern = _scoped_match_pattern(rel_type, direction)
 
@@ -263,10 +257,6 @@ async def get_paginated_section_connections(
         "pubkey": pubkey,
         "influence_key": influence_key,
         "limit": limit,
-        "verified_threshold": verified_threshold,
-        "tier_high": tier_high,
-        "tier_trusted": tier_trusted,
-        "tier_neutral": tier_neutral,
     }
     cursor_clause = ""
     if cursor_inf is not None and cursor_pk is not None:
@@ -277,32 +267,8 @@ async def get_paginated_section_connections(
             "OR (sort_inf = $cursor_inf AND other.pubkey > $cursor_pk)"
         )
 
-    stats_subquery = (
-        f"""
-        CALL (user) {{
-            MATCH {scoped_pattern}
-            RETURN
-                count(*) AS total,
-                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $verified_threshold THEN 1 END) AS verified,
-                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_high THEN 1 END) AS tier_high,
-                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_trusted AND other[$influence_key] < $tier_high THEN 1 END) AS tier_trusted,
-                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_neutral AND other[$influence_key] < $tier_trusted THEN 1 END) AS tier_neutral,
-                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $verified_threshold AND other[$influence_key] < $tier_neutral THEN 1 END) AS tier_low,
-                count(CASE WHEN other[$influence_key] IS NULL OR other[$influence_key] < $verified_threshold THEN 1 END) AS tier_unverified
-        }}
-        """
-        if compute_stats
-        else ""
-    )
-    stats_return = (
-        ", total, verified, tier_high, tier_trusted, tier_neutral, tier_low, tier_unverified"
-        if compute_stats
-        else ""
-    )
-
     query = f"""
     MATCH (user:NostrUser {{pubkey: $pubkey}})
-    {stats_subquery}
     CALL (user) {{
         MATCH {scoped_pattern}
         WITH other, coalesce(other[$influence_key], -1.0) AS sort_inf
@@ -313,7 +279,7 @@ async def get_paginated_section_connections(
         ORDER BY sort_inf DESC, other.pubkey ASC
         LIMIT $limit
     }}
-    RETURN pubkey, influence, sort_inf{stats_return}
+    RETURN pubkey, influence, sort_inf
     """
 
     result = await session.run(query, **params)
@@ -332,31 +298,7 @@ async def get_paginated_section_connections(
         last = records[-1]
         last_cursor = (float(last["sort_inf"]), str(last["pubkey"]))
 
-    stats: ConnectionStats | None = None
-    if compute_stats:
-        if records:
-            first = records[0]
-            stats = ConnectionStats(
-                total=int(first["total"] or 0),
-                verified=int(first["verified"] or 0),
-                tier_counts=ConnectionTierCounts(
-                    high=int(first["tier_high"] or 0),
-                    trusted=int(first["tier_trusted"] or 0),
-                    neutral=int(first["tier_neutral"] or 0),
-                    low=int(first["tier_low"] or 0),
-                    unverified=int(first["tier_unverified"] or 0),
-                ),
-            )
-        else:
-            stats = ConnectionStats(
-                total=0,
-                verified=0,
-                tier_counts=ConnectionTierCounts(
-                    high=0, trusted=0, neutral=0, low=0, unverified=0
-                ),
-            )
-
-    return items, stats, last_cursor
+    return items, last_cursor
 
 
 _STATS_KINDS: list[tuple[str, str, str]] = [

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -4,6 +4,7 @@ from app.schemas.schemas import (
     ConnectionStats,
     ConnectionTierCounts,
     UserConnection,
+    UserConnectionItem,
     UserGraphData,
 )
 
@@ -240,7 +241,6 @@ async def get_paginated_section_connections(
     session: AsyncNeoDriver,
     pubkey: str,
     influence_key: str,
-    trusted_reporters_key: str,
     rel_type: str,
     direction: str,
     limit: int,
@@ -251,7 +251,7 @@ async def get_paginated_section_connections(
     tier_high: float,
     tier_trusted: float,
     tier_neutral: float,
-) -> tuple[list[UserConnection], ConnectionStats | None, tuple[float, str] | None]:
+) -> tuple[list[UserConnectionItem], ConnectionStats | None, tuple[float, str] | None]:
     """Cursor-paginated connection list ordered by (influence DESC, pubkey ASC).
     On first page (no cursor), also returns ConnectionStats in a single query.
 
@@ -262,7 +262,6 @@ async def get_paginated_section_connections(
     params: dict = {
         "pubkey": pubkey,
         "influence_key": influence_key,
-        "trusted_reporters_key": trusted_reporters_key,
         "limit": limit,
         "verified_threshold": verified_threshold,
         "tier_high": tier_high,
@@ -310,22 +309,20 @@ async def get_paginated_section_connections(
         {cursor_clause}
         RETURN other.pubkey AS pubkey,
                other[$influence_key] AS influence,
-               other[$trusted_reporters_key] AS trusted_reporters,
                sort_inf
         ORDER BY sort_inf DESC, other.pubkey ASC
         LIMIT $limit
     }}
-    RETURN pubkey, influence, trusted_reporters, sort_inf{stats_return}
+    RETURN pubkey, influence, sort_inf{stats_return}
     """
 
     result = await session.run(query, **params)
     records = [rec async for rec in result]
 
     items = [
-        UserConnection(
+        UserConnectionItem(
             pubkey=rec["pubkey"],
             influence=rec["influence"],
-            trusted_reporters=rec["trusted_reporters"],
         )
         for rec in records
     ]

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -1,6 +1,11 @@
 from neo4j import AsyncDriver as AsyncNeoDriver
 
-from app.schemas.schemas import UserConnection
+from app.schemas.schemas import (
+    ConnectionStats,
+    ConnectionTierCounts,
+    UserConnection,
+    UserGraphData,
+)
 
 
 # ----------------- Helper Function -----------------
@@ -189,3 +194,356 @@ async def get_influence_for_observer(
     result = await session.run(query, pubkey=pubkey, property_name=property_name)
     record = await result.single()
     return record["influence"] if record and record["influence"] is not None else None
+
+
+# ----------------- overview / stats / paginated connections -----------------
+#
+# Notes on the Cypher patterns below:
+# - Match pattern direction "in" = (other)-[:REL]->(user); "out" = (user)-[:REL]->(other).
+# - Neo4j quirk: `WITH other[$dynamic_key] AS inf` aliases the value as Infinity
+#   for every row. Inline `other[$influence_key]` in CASE WHEN / RETURN to get
+#   real values. Wrapping in `coalesce(other[$key], default)` also works.
+
+
+def _scoped_match_pattern(rel_type: str, direction: str) -> str:
+    """MATCH pattern assuming `user` is already bound in the surrounding scope
+    (e.g. inside a `CALL (user)` subquery)."""
+    if direction == "in":
+        return f"(other:NostrUser)-[:{rel_type}]->(user)"
+    return f"(user)-[:{rel_type}]->(other:NostrUser)"
+
+
+async def get_outbound_counts_and_influence(
+    session: AsyncNeoDriver, pubkey: str, influence_key: str
+) -> tuple[float | None, int, int, int]:
+    """One round-trip: user's own influence + counts of following/muting/reporting."""
+    query = """
+    MATCH (user:NostrUser {pubkey: $pubkey})
+    CALL (user) { MATCH (user)-[:FOLLOWS]->(o:NostrUser)  RETURN count(o) AS following }
+    CALL (user) { MATCH (user)-[:MUTES]->(o:NostrUser)    RETURN count(o) AS muting }
+    CALL (user) { MATCH (user)-[:REPORTS]->(o:NostrUser)  RETURN count(o) AS reporting }
+    RETURN user[$influence_key] AS influence, following, muting, reporting
+    """
+    result = await session.run(query, pubkey=pubkey, influence_key=influence_key)
+    record = await result.single()
+    if not record:
+        return None, 0, 0, 0
+    return (
+        record["influence"],
+        int(record["following"] or 0),
+        int(record["muting"] or 0),
+        int(record["reporting"] or 0),
+    )
+
+
+async def get_paginated_section_connections(
+    session: AsyncNeoDriver,
+    pubkey: str,
+    influence_key: str,
+    trusted_reporters_key: str,
+    rel_type: str,
+    direction: str,
+    limit: int,
+    cursor_inf: float | None,
+    cursor_pk: str | None,
+    compute_stats: bool,
+    verified_threshold: float,
+    tier_high: float,
+    tier_trusted: float,
+    tier_neutral: float,
+) -> tuple[list[UserConnection], ConnectionStats | None, tuple[float, str] | None]:
+    """Cursor-paginated connection list ordered by (influence DESC, pubkey ASC).
+    On first page (no cursor), also returns ConnectionStats in a single query.
+
+    Returns (items, stats_or_none, last_record_cursor_or_none).
+    """
+    scoped_pattern = _scoped_match_pattern(rel_type, direction)
+
+    params: dict = {
+        "pubkey": pubkey,
+        "influence_key": influence_key,
+        "trusted_reporters_key": trusted_reporters_key,
+        "limit": limit,
+        "verified_threshold": verified_threshold,
+        "tier_high": tier_high,
+        "tier_trusted": tier_trusted,
+        "tier_neutral": tier_neutral,
+    }
+    cursor_clause = ""
+    if cursor_inf is not None and cursor_pk is not None:
+        params["cursor_inf"] = cursor_inf
+        params["cursor_pk"] = cursor_pk
+        cursor_clause = (
+            "WHERE sort_inf < $cursor_inf "
+            "OR (sort_inf = $cursor_inf AND other.pubkey > $cursor_pk)"
+        )
+
+    stats_subquery = (
+        f"""
+        CALL (user) {{
+            MATCH {scoped_pattern}
+            RETURN
+                count(*) AS total,
+                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $verified_threshold THEN 1 END) AS verified,
+                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_high THEN 1 END) AS tier_high,
+                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_trusted AND other[$influence_key] < $tier_high THEN 1 END) AS tier_trusted,
+                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_neutral AND other[$influence_key] < $tier_trusted THEN 1 END) AS tier_neutral,
+                count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $verified_threshold AND other[$influence_key] < $tier_neutral THEN 1 END) AS tier_low,
+                count(CASE WHEN other[$influence_key] IS NULL OR other[$influence_key] < $verified_threshold THEN 1 END) AS tier_unverified
+        }}
+        """
+        if compute_stats
+        else ""
+    )
+    stats_return = (
+        ", total, verified, tier_high, tier_trusted, tier_neutral, tier_low, tier_unverified"
+        if compute_stats
+        else ""
+    )
+
+    query = f"""
+    MATCH (user:NostrUser {{pubkey: $pubkey}})
+    {stats_subquery}
+    CALL (user) {{
+        MATCH {scoped_pattern}
+        WITH other, coalesce(other[$influence_key], -1.0) AS sort_inf
+        {cursor_clause}
+        RETURN other.pubkey AS pubkey,
+               other[$influence_key] AS influence,
+               other[$trusted_reporters_key] AS trusted_reporters,
+               sort_inf
+        ORDER BY sort_inf DESC, other.pubkey ASC
+        LIMIT $limit
+    }}
+    RETURN pubkey, influence, trusted_reporters, sort_inf{stats_return}
+    """
+
+    result = await session.run(query, **params)
+    records = [rec async for rec in result]
+
+    items = [
+        UserConnection(
+            pubkey=rec["pubkey"],
+            influence=rec["influence"],
+            trusted_reporters=rec["trusted_reporters"],
+        )
+        for rec in records
+    ]
+
+    last_cursor: tuple[float, str] | None = None
+    if len(records) == limit and records:
+        last = records[-1]
+        last_cursor = (float(last["sort_inf"]), str(last["pubkey"]))
+
+    stats: ConnectionStats | None = None
+    if compute_stats:
+        if records:
+            first = records[0]
+            stats = ConnectionStats(
+                total=int(first["total"] or 0),
+                verified=int(first["verified"] or 0),
+                tier_counts=ConnectionTierCounts(
+                    high=int(first["tier_high"] or 0),
+                    trusted=int(first["tier_trusted"] or 0),
+                    neutral=int(first["tier_neutral"] or 0),
+                    low=int(first["tier_low"] or 0),
+                    unverified=int(first["tier_unverified"] or 0),
+                ),
+            )
+        else:
+            stats = ConnectionStats(
+                total=0,
+                verified=0,
+                tier_counts=ConnectionTierCounts(
+                    high=0, trusted=0, neutral=0, low=0, unverified=0
+                ),
+            )
+
+    return items, stats, last_cursor
+
+
+_STATS_KINDS: list[tuple[str, str, str]] = [
+    ("followed_by", "FOLLOWS", "in"),
+    ("following", "FOLLOWS", "out"),
+    ("muted_by", "MUTES", "in"),
+    ("muting", "MUTES", "out"),
+    ("reported_by", "REPORTS", "in"),
+    ("reporting", "REPORTS", "out"),
+]
+
+
+async def get_all_section_stats(
+    session: AsyncNeoDriver,
+    pubkey: str,
+    influence_key: str,
+    verified_threshold: float,
+    tier_high: float,
+    tier_trusted: float,
+    tier_neutral: float,
+) -> dict[str, ConnectionStats]:
+    """Single-query version of get_section_stats covering all 6 relationships.
+    ~20% faster than 6 parallel sessions on heavy accounts (1 round-trip)."""
+    blocks: list[str] = ["MATCH (user:NostrUser {pubkey: $pubkey})"]
+    return_fields: list[str] = []
+    for name, rel_type, direction in _STATS_KINDS:
+        pattern = _scoped_match_pattern(rel_type, direction)
+        blocks.append(
+            f"""
+        CALL (user) {{
+            MATCH {pattern}
+            RETURN
+              count(*) AS {name}_total,
+              count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $vt THEN 1 END) AS {name}_verified,
+              count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_high THEN 1 END) AS {name}_th,
+              count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_trusted AND other[$influence_key] < $tier_high THEN 1 END) AS {name}_tt,
+              count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $tier_neutral AND other[$influence_key] < $tier_trusted THEN 1 END) AS {name}_tn,
+              count(CASE WHEN other[$influence_key] IS NOT NULL AND other[$influence_key] >= $vt AND other[$influence_key] < $tier_neutral THEN 1 END) AS {name}_tl,
+              count(CASE WHEN other[$influence_key] IS NULL OR other[$influence_key] < $vt THEN 1 END) AS {name}_tu
+        }}"""
+        )
+        return_fields.extend(
+            f"{name}_{suffix}"
+            for suffix in ("total", "verified", "th", "tt", "tn", "tl", "tu")
+        )
+    blocks.append("RETURN " + ", ".join(return_fields))
+    query = "\n".join(blocks)
+
+    result = await session.run(
+        query,
+        pubkey=pubkey,
+        influence_key=influence_key,
+        vt=verified_threshold,
+        tier_high=tier_high,
+        tier_trusted=tier_trusted,
+        tier_neutral=tier_neutral,
+    )
+    record = await result.single()
+
+    def _empty() -> ConnectionStats:
+        return ConnectionStats(
+            total=0,
+            verified=0,
+            tier_counts=ConnectionTierCounts(
+                high=0, trusted=0, neutral=0, low=0, unverified=0
+            ),
+        )
+
+    if not record:
+        return {name: _empty() for name, _, _ in _STATS_KINDS}
+
+    return {
+        name: ConnectionStats(
+            total=int(record[f"{name}_total"] or 0),
+            verified=int(record[f"{name}_verified"] or 0),
+            tier_counts=ConnectionTierCounts(
+                high=int(record[f"{name}_th"] or 0),
+                trusted=int(record[f"{name}_tt"] or 0),
+                neutral=int(record[f"{name}_tn"] or 0),
+                low=int(record[f"{name}_tl"] or 0),
+                unverified=int(record[f"{name}_tu"] or 0),
+            ),
+        )
+        for name, _, _ in _STATS_KINDS
+    }
+
+
+async def get_user_graph_data(
+    session: AsyncNeoDriver,
+    pubkey: str,
+    influence_key: str,
+    trusted_reporters_key: str,
+) -> UserGraphData:
+    """Single Cypher returning all 6 relationship lists (full, unpaginated) plus
+    the user's own influence — used by /self and /user/{pubkey}."""
+    query = """
+    MATCH (user:NostrUser {pubkey: $pubkey})
+
+    CALL (user) {
+        MATCH (other:NostrUser)-[:FOLLOWS]->(user)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS followed_by
+    }
+
+    CALL (user) {
+        MATCH (user)-[:FOLLOWS]->(other:NostrUser)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS following
+    }
+
+    CALL (user) {
+        MATCH (other:NostrUser)-[:MUTES]->(user)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS muted_by
+    }
+
+    CALL (user) {
+        MATCH (user)-[:MUTES]->(other:NostrUser)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS muting
+    }
+
+    CALL (user) {
+        MATCH (other:NostrUser)-[:REPORTS]->(user)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS reported_by
+    }
+
+    CALL (user) {
+        MATCH (user)-[:REPORTS]->(other:NostrUser)
+        RETURN collect({
+            pubkey: other.pubkey,
+            influence: other[$influence_key],
+            trusted_reporters: other[$trusted_reporters_key]
+        }) AS reporting
+    }
+
+    RETURN
+        user[$influence_key] AS influence,
+        followed_by,
+        following,
+        muted_by,
+        muting,
+        reported_by,
+        reporting
+    """
+    result = await session.run(
+        query,
+        pubkey=pubkey,
+        influence_key=influence_key,
+        trusted_reporters_key=trusted_reporters_key,
+    )
+    record = await result.single()
+    if not record:
+        return UserGraphData(
+            influence=None,
+            followed_by=[],
+            following=[],
+            muted_by=[],
+            muting=[],
+            reported_by=[],
+            reporting=[],
+        )
+    return UserGraphData(
+        influence=record["influence"],
+        followed_by=[UserConnection(**x) for x in record["followed_by"]],
+        following=[UserConnection(**x) for x in record["following"]],
+        muted_by=[UserConnection(**x) for x in record["muted_by"]],
+        muting=[UserConnection(**x) for x in record["muting"]],
+        reported_by=[UserConnection(**x) for x in record["reported_by"]],
+        reporting=[UserConnection(**x) for x in record["reporting"]],
+    )

--- a/app/routers/user/router.py
+++ b/app/routers/user/router.py
@@ -199,7 +199,6 @@ async def get_user_connections_endpoint(
     kind: ConnectionKind = Query(..., description="Which relationship list to fetch"),
     limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     cursor: str | None = Query(default=None),
-    verified_threshold: float = Query(default=DEFAULT_VERIFIED_THRESHOLD, ge=0.0, le=1.0),
 ) -> GetUserConnectionsResponse:
     jwt_data: JWTData = request.state.jwt_data
     result = await get_user_connections(
@@ -208,7 +207,6 @@ async def get_user_connections_endpoint(
         kind=kind,
         limit=limit,
         cursor=cursor,
-        verified_threshold=verified_threshold,
     )
     return GetUserConnectionsResponse(data=result)
 

--- a/app/routers/user/router.py
+++ b/app/routers/user/router.py
@@ -1,13 +1,17 @@
+import asyncio
 from datetime import datetime, timedelta
 from app.utils.rate_limiting.rate_limiting import validateIfRequestedTooOftenByIP
 from fastapi import HTTPException
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from app.core.database import get_db
 from app.schemas.request_body_schemas import SubmitNostrAuthChallengeBody
 from app.schemas.request_response_schemas import (
     GetOwnLatestGraperankResponse,
     GetOwnUserDataResponse,
+    GetUserConnectionsResponse,
     GetUserDataResponse,
+    GetUserOverviewResponse,
+    GetUserStatsResponse,
     PublishAssistantProfileData,
     PublishAssistantProfileResponse,
 )
@@ -18,9 +22,19 @@ from app.schemas.schemas import OwnUserData
 from app.services.assistant_profile_service import publish_assistant_kind0_for_user
 from app.services.brainstorm_request_service import create_brainstorm_request
 from app.services.user_service import (
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_VERIFIED_THRESHOLD,
+    MAX_PAGE_SIZE,
+    TIER_HIGH,
+    TIER_NEUTRAL,
+    TIER_TRUSTED,
+    ConnectionKind,
     get_own_latest_graperank,
+    get_user_connections,
     get_user_graph_data,
     get_user_history_data,
+    get_user_overview,
+    get_user_stats,
 )
 from app.utils.auth.auth_models import JWTData
 
@@ -104,9 +118,10 @@ async def get_own_user_data_endpoint(
     jwt_data: JWTData = request.state.jwt_data
     user_pubkey = jwt_data.nostr_pubkey
 
-    result = await get_user_graph_data(user_pubkey)
-
-    history = await get_user_history_data(db, user_pubkey)
+    result, history = await asyncio.gather(
+        get_user_graph_data(user_pubkey),
+        get_user_history_data(db, user_pubkey),
+    )
 
     return GetOwnUserDataResponse(data=OwnUserData(graph=result, history=history))
 
@@ -135,6 +150,67 @@ async def publish_assistant_profile_endpoint(
             assistant_pubkey=assistant_pubkey,
         )
     )
+
+
+@router.get(
+    path="/{pubkey}/overview",
+    summary="Lightweight overview: influence + relationship counts",
+)
+async def get_user_overview_endpoint(
+    request: Request,
+    pubkey: str,
+) -> GetUserOverviewResponse:
+    jwt_data: JWTData = request.state.jwt_data
+    result = await get_user_overview(pubkey=pubkey, observer=jwt_data.nostr_pubkey)
+    return GetUserOverviewResponse(data=result)
+
+
+@router.get(
+    path="/{pubkey}/stats",
+    summary="Per-section stats: total + verified + tier counts for all 6 relationships",
+)
+async def get_user_stats_endpoint(
+    request: Request,
+    pubkey: str,
+    verified_threshold: float = Query(default=DEFAULT_VERIFIED_THRESHOLD, ge=0.0, le=1.0),
+    tier_high: float = Query(default=TIER_HIGH, ge=0.0, le=1.0),
+    tier_trusted: float = Query(default=TIER_TRUSTED, ge=0.0, le=1.0),
+    tier_neutral: float = Query(default=TIER_NEUTRAL, ge=0.0, le=1.0),
+) -> GetUserStatsResponse:
+    jwt_data: JWTData = request.state.jwt_data
+    result = await get_user_stats(
+        pubkey=pubkey,
+        observer=jwt_data.nostr_pubkey,
+        verified_threshold=verified_threshold,
+        tier_high=tier_high,
+        tier_trusted=tier_trusted,
+        tier_neutral=tier_neutral,
+    )
+    return GetUserStatsResponse(data=result)
+
+
+@router.get(
+    path="/{pubkey}/connections",
+    summary="Paginated connection list for a given kind",
+)
+async def get_user_connections_endpoint(
+    request: Request,
+    pubkey: str,
+    kind: ConnectionKind = Query(..., description="Which relationship list to fetch"),
+    limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    cursor: str | None = Query(default=None),
+    verified_threshold: float = Query(default=DEFAULT_VERIFIED_THRESHOLD, ge=0.0, le=1.0),
+) -> GetUserConnectionsResponse:
+    jwt_data: JWTData = request.state.jwt_data
+    result = await get_user_connections(
+        pubkey=pubkey,
+        observer=jwt_data.nostr_pubkey,
+        kind=kind,
+        limit=limit,
+        cursor=cursor,
+        verified_threshold=verified_threshold,
+    )
+    return GetUserConnectionsResponse(data=result)
 
 
 @router.get(

--- a/app/schemas/request_response_schemas.py
+++ b/app/schemas/request_response_schemas.py
@@ -9,7 +9,10 @@ from app.schemas.schemas import (
     BrainstormPubkeyInstance,
     BrainstormRequestInstance,
     OwnUserData,
+    PaginatedUserConnections,
     UserGraphData,
+    UserOverviewData,
+    UserSectionsStats,
 )
 from app.schemas.graperank_schemas import (
     BuiltinPresetTemplate,
@@ -62,6 +65,18 @@ class SubmitNostrAuthChallengeResponse(SuccessfulResponseDataSchema):
 
 class GetUserDataResponse(SuccessfulResponseDataSchema):
     data: UserGraphData
+
+
+class GetUserOverviewResponse(SuccessfulResponseDataSchema):
+    data: UserOverviewData
+
+
+class GetUserConnectionsResponse(SuccessfulResponseDataSchema):
+    data: PaginatedUserConnections
+
+
+class GetUserStatsResponse(SuccessfulResponseDataSchema):
+    data: UserSectionsStats
 
 
 class GetOwnUserDataResponse(SuccessfulResponseDataSchema):

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -154,7 +154,6 @@ class UserConnectionItem(BaseModel):
 class PaginatedUserConnections(BaseModel):
     items: list[UserConnectionItem]
     next_cursor: str | None = None
-    stats: ConnectionStats | None = None
 
 
 class UserSectionsStats(BaseModel):

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -115,3 +115,47 @@ class UserHistoryInstance(CreatedAndUpdatedAtModel):
 class OwnUserData(BaseModel):
     graph: UserGraphData
     history: UserHistoryInstance
+
+
+class UserConnectionCounts(BaseModel):
+    followed_by: int
+    following: int
+    muted_by: int
+    muting: int
+    reported_by: int
+    reporting: int
+
+
+class UserOverviewData(BaseModel):
+    pubkey: str
+    influence: float | None
+    counts: UserConnectionCounts
+
+
+class ConnectionTierCounts(BaseModel):
+    high: int
+    trusted: int
+    neutral: int
+    low: int
+    unverified: int
+
+
+class ConnectionStats(BaseModel):
+    total: int
+    verified: int
+    tier_counts: ConnectionTierCounts
+
+
+class PaginatedUserConnections(BaseModel):
+    items: list[UserConnection]
+    next_cursor: str | None = None
+    stats: ConnectionStats | None = None
+
+
+class UserSectionsStats(BaseModel):
+    followed_by: ConnectionStats
+    following: ConnectionStats
+    muted_by: ConnectionStats
+    muting: ConnectionStats
+    reported_by: ConnectionStats
+    reporting: ConnectionStats

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -146,8 +146,13 @@ class ConnectionStats(BaseModel):
     tier_counts: ConnectionTierCounts
 
 
+class UserConnectionItem(BaseModel):
+    pubkey: str
+    influence: float | None = None
+
+
 class PaginatedUserConnections(BaseModel):
-    items: list[UserConnection]
+    items: list[UserConnectionItem]
     next_cursor: str | None = None
     stats: ConnectionStats | None = None
 

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -31,8 +31,8 @@ from app.repos.user_repo import (
 from app.schemas.schemas import (
     BrainstormRequestInstance,
     PaginatedUserConnections,
-    UserConnection,
     UserConnectionCounts,
+    UserConnectionItem,
     UserGraphData,
     UserHistoryInstance,
     UserOverviewData,
@@ -233,9 +233,6 @@ async def get_user_connections(
     limit = max(1, min(limit, MAX_PAGE_SIZE))
     rel_type, direction = _KIND_TO_REL[kind]
     influence_key = f"influence_{observer}" if observer else f"influence_{pubkey}"
-    trusted_reporters_key = (
-        f"trusted_reporters_{observer}" if observer else f"trusted_reporters_{pubkey}"
-    )
 
     cursor_inf, cursor_pk = (None, None)
     if cursor:
@@ -253,7 +250,6 @@ async def get_user_connections(
             session,
             pubkey=pubkey,
             influence_key=influence_key,
-            trusted_reporters_key=trusted_reporters_key,
             rel_type=rel_type,
             direction=direction,
             limit=limit,
@@ -268,10 +264,9 @@ async def get_user_connections(
 
     # Sanitize NaN/Inf floats post-query for safe JSON encoding.
     items = [
-        UserConnection(
+        UserConnectionItem(
             pubkey=it.pubkey,
             influence=_safe_float(it.influence),
-            trusted_reporters=it.trusted_reporters,
         )
         for it in items
     ]

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -228,7 +228,6 @@ async def get_user_connections(
     kind: ConnectionKind = "following",
     limit: int = DEFAULT_PAGE_SIZE,
     cursor: str | None = None,
-    verified_threshold: float = DEFAULT_VERIFIED_THRESHOLD,
 ) -> PaginatedUserConnections:
     limit = max(1, min(limit, MAX_PAGE_SIZE))
     rel_type, direction = _KIND_TO_REL[kind]
@@ -243,10 +242,9 @@ async def get_user_connections(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="invalid cursor",
             )
-    compute_stats = cursor is None
 
     async with neo4j_driver.session() as session:
-        items, stats, last_cursor = await get_paginated_section_connections(
+        items, last_cursor = await get_paginated_section_connections(
             session,
             pubkey=pubkey,
             influence_key=influence_key,
@@ -255,11 +253,6 @@ async def get_user_connections(
             limit=limit,
             cursor_inf=cursor_inf,
             cursor_pk=cursor_pk,
-            compute_stats=compute_stats,
-            verified_threshold=verified_threshold,
-            tier_high=TIER_HIGH,
-            tier_trusted=TIER_TRUSTED,
-            tier_neutral=TIER_NEUTRAL,
         )
 
     # Sanitize NaN/Inf floats post-query for safe JSON encoding.
@@ -277,9 +270,7 @@ async def get_user_connections(
         if last_sort_inf is not None:
             next_cursor = _encode_cursor(last_sort_inf, last_cursor[1])
 
-    return PaginatedUserConnections(
-        items=items, next_cursor=next_cursor, stats=stats
-    )
+    return PaginatedUserConnections(items=items, next_cursor=next_cursor)
 
 
 async def get_whitelisted_pubkeys_of_observer(

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,32 +1,112 @@
+import asyncio
+import base64
+import binascii
+import json
+import math
+from typing import Literal
+
+from fastapi import HTTPException, status
+
+from app.core.redis_db import redis_client
 from app.db_models import BrainstormNsec, BrainstormRequestStatus
+from app.message_queue_tasks.process_strfry_event import (
+    FOLLOWED_BY_KEY_PREFIX,
+    MUTED_BY_KEY_PREFIX,
+    REPORTED_BY_KEY_PREFIX,
+)
 from app.models.grapeRankResult import GrapeRankResult
 from app.neo4j_db.driver import driver as neo4j_driver
-from app.repos.brainstorm_nsec import select_brainstorm_nsec_by_pubkey_on_db
+from app.repos.brainstorm_nsec import select_brainstorm_nsec_history_fields_on_db
 from app.repos.brainstorm_request_repo import (
     count_brainstorm_requests_with_priority_over_one_on_db,
     select_latest_brainstorm_request_on_db,
     select_latest_successful_brainstorm_request_on_db,
 )
 from app.repos.user_repo import (
-    get_influence_for_observer,
-    get_list_of_pubkeys_following_user,
-    get_list_of_pubkeys_that_user_follows,
-    get_list_of_pubkeys_that_user_mutes,
-    get_list_of_pubkeys_muting_user,
-    get_list_of_pubkeys_reporting_user,
-    get_list_of_pubkeys_that_user_reports,
+    get_all_section_stats,
+    get_outbound_counts_and_influence,
+    get_paginated_section_connections,
+    get_user_graph_data as _repo_get_user_graph_data,
 )
 from app.schemas.schemas import (
     BrainstormRequestInstance,
+    PaginatedUserConnections,
     UserConnection,
+    UserConnectionCounts,
     UserGraphData,
     UserHistoryInstance,
+    UserOverviewData,
+    UserSectionsStats,
 )
 from sqlalchemy.ext.asyncio import AsyncSession as AsyncDBSession
 from nostr_sdk import Keys
 from app.services.brainstorm_request_service import (
     brainstorm_request_db_obj_to_schema_converter,
 )
+
+# Tier boundaries match the FE (high ≥ 0.5, trusted ≥ 0.2, neutral ≥ 0.07).
+# The verified_threshold separates "low" from "unverified" — passed per request
+# since it depends on the user's selected trust preset.
+TIER_HIGH = 0.50
+TIER_TRUSTED = 0.20
+TIER_NEUTRAL = 0.07
+DEFAULT_VERIFIED_THRESHOLD = 0.02
+
+MAX_PAGE_SIZE = 200
+DEFAULT_PAGE_SIZE = 50
+
+ConnectionKind = Literal[
+    "followed_by", "following", "muted_by", "muting", "reported_by", "reporting"
+]
+
+# (relationship_type, direction). direction "in" = other -[r]-> user, "out" = user -[r]-> other.
+_KIND_TO_REL: dict[ConnectionKind, tuple[str, str]] = {
+    "followed_by": ("FOLLOWS", "in"),
+    "following": ("FOLLOWS", "out"),
+    "muted_by": ("MUTES", "in"),
+    "muting": ("MUTES", "out"),
+    "reported_by": ("REPORTS", "in"),
+    "reporting": ("REPORTS", "out"),
+}
+
+
+def _safe_float(value) -> float | None:
+    # Neo4j can return inf/nan for stale or unbacked influence properties.
+    # json.dumps rejects these, so coerce to None for the wire.
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isinf(f) or math.isnan(f):
+        return None
+    return f
+
+
+def _encode_cursor(sort_inf: float, pubkey: str) -> str:
+    return base64.urlsafe_b64encode(
+        json.dumps({"i": sort_inf, "p": pubkey}).encode()
+    ).decode()
+
+
+def _decode_cursor(cursor: str) -> tuple[float, str]:
+    payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    return float(payload["i"]), str(payload["p"])
+
+
+async def _redis_inbound_count(prefix: str, pubkey: str) -> int:
+    return int(await redis_client.scard(f"{prefix}{pubkey}"))
+
+
+async def _neo4j_outbound_counts_and_influence(
+    pubkey: str, influence_key: str
+) -> tuple[float | None, int, int, int]:
+    async with neo4j_driver.session() as session:
+        influence, following, muting, reporting = (
+            await get_outbound_counts_and_influence(session, pubkey, influence_key)
+        )
+    return _safe_float(influence), following, muting, reporting
 
 
 def brainstorm_nsec_db_obj_to_user_history_schema_converter(
@@ -77,152 +157,133 @@ async def get_user_graph_data(
     trusted_reporters_key = (
         f"trusted_reporters_{observer}" if observer else f"trusted_reporters_{pubkey}"
     )
-
-    query = """
-    MATCH (user:NostrUser {pubkey: $pubkey})
-
-    CALL (user) {
-        MATCH (other:NostrUser)-[:FOLLOWS]->(user)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS followed_by
-    }
-
-    CALL (user) {
-        MATCH (user)-[:FOLLOWS]->(other:NostrUser)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS following
-    }
-
-    CALL (user) {
-        MATCH (other:NostrUser)-[:MUTES]->(user)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS muted_by
-    }
-
-    CALL (user) {
-        MATCH (user)-[:MUTES]->(other:NostrUser)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS muting
-    }
-
-    CALL (user) {
-        MATCH (other:NostrUser)-[:REPORTS]->(user)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS reported_by
-    }
-
-    CALL (user) {
-        MATCH (user)-[:REPORTS]->(other:NostrUser)
-        RETURN collect({
-            pubkey: other.pubkey,
-            influence: other[$influence_key],
-            trusted_reporters: other[$trusted_reporters_key]
-        }) AS reporting
-    }
-
-    RETURN
-        user[$influence_key] AS influence,
-        followed_by,
-        following,
-        muted_by,
-        muting,
-        reported_by,
-        reporting
-    """
-
     async with neo4j_driver.session() as session:
-        result = await session.run(
-            query,
-            pubkey=pubkey,
-            influence_key=influence_key,
-            trusted_reporters_key=trusted_reporters_key,
+        return await _repo_get_user_graph_data(
+            session, pubkey, influence_key, trusted_reporters_key
         )
-
-        record = await result.single()
-
-    if not record:
-        return UserGraphData(
-            influence=None,
-            followed_by=[],
-            following=[],
-            muted_by=[],
-            muting=[],
-            reported_by=[],
-            reporting=[],
-        )
-
-    return UserGraphData(
-        influence=record["influence"],
-        followed_by=[UserConnection(**x) for x in record["followed_by"]],
-        following=[UserConnection(**x) for x in record["following"]],
-        muted_by=[UserConnection(**x) for x in record["muted_by"]],
-        muting=[UserConnection(**x) for x in record["muting"]],
-        reported_by=[UserConnection(**x) for x in record["reported_by"]],
-        reporting=[UserConnection(**x) for x in record["reporting"]],
-    )
-
-
-async def get_user_graph_data_old(
-    pubkey: str, observer: str | None = None
-) -> UserGraphData:
-
-    async with neo4j_driver.session() as neo4j_session:
-        followed_by = await get_list_of_pubkeys_following_user(
-            neo4j_session, pubkey, observer
-        )
-        following = await get_list_of_pubkeys_that_user_follows(
-            neo4j_session, pubkey, observer
-        )
-        muted_by = await get_list_of_pubkeys_muting_user(
-            neo4j_session, pubkey, observer
-        )
-        muting = await get_list_of_pubkeys_that_user_mutes(
-            neo4j_session, pubkey, observer
-        )
-        reported_by = await get_list_of_pubkeys_reporting_user(
-            neo4j_session, pubkey, observer
-        )
-        reporting = await get_list_of_pubkeys_that_user_reports(
-            neo4j_session, pubkey, observer
-        )
-        influence = (
-            1
-            if observer is None
-            else await get_influence_for_observer(neo4j_session, pubkey, observer)
-        )
-
-    return UserGraphData(
-        influence=influence,
-        followed_by=followed_by,
-        following=following,
-        muted_by=muted_by,
-        muting=muting,
-        reported_by=reported_by,
-        reporting=reporting,
-    )
 
 
 async def get_user_history_data(db: AsyncDBSession, pubkey: str) -> UserHistoryInstance:
-
-    brainstorm_nsec_db_obj = await select_brainstorm_nsec_by_pubkey_on_db(db, pubkey)
-
+    brainstorm_nsec_db_obj = await select_brainstorm_nsec_history_fields_on_db(db, pubkey)
     return brainstorm_nsec_db_obj_to_user_history_schema_converter(
         brainstorm_nsec_db_obj=brainstorm_nsec_db_obj,
+    )
+
+
+async def get_user_overview(
+    pubkey: str, observer: str | None = None
+) -> UserOverviewData:
+    influence_key = f"influence_{observer}" if observer else f"influence_{pubkey}"
+
+    # Redis SCARD for inbound + one Neo4j query for outbound counts + influence,
+    # all in parallel.
+    followed_by, muted_by, reported_by, neo_result = await asyncio.gather(
+        _redis_inbound_count(FOLLOWED_BY_KEY_PREFIX, pubkey),
+        _redis_inbound_count(MUTED_BY_KEY_PREFIX, pubkey),
+        _redis_inbound_count(REPORTED_BY_KEY_PREFIX, pubkey),
+        _neo4j_outbound_counts_and_influence(pubkey, influence_key),
+    )
+    influence, following, muting, reporting = neo_result
+
+    return UserOverviewData(
+        pubkey=pubkey,
+        influence=influence,
+        counts=UserConnectionCounts(
+            followed_by=followed_by,
+            following=following,
+            muted_by=muted_by,
+            muting=muting,
+            reported_by=reported_by,
+            reporting=reporting,
+        ),
+    )
+
+
+async def get_user_stats(
+    pubkey: str,
+    observer: str | None = None,
+    verified_threshold: float = DEFAULT_VERIFIED_THRESHOLD,
+    tier_high: float = TIER_HIGH,
+    tier_trusted: float = TIER_TRUSTED,
+    tier_neutral: float = TIER_NEUTRAL,
+) -> UserSectionsStats:
+    influence_key = f"influence_{observer}" if observer else f"influence_{pubkey}"
+
+    async with neo4j_driver.session() as session:
+        stats_by_kind = await get_all_section_stats(
+            session,
+            pubkey,
+            influence_key,
+            verified_threshold,
+            tier_high,
+            tier_trusted,
+            tier_neutral,
+        )
+    return UserSectionsStats(**stats_by_kind)
+
+
+async def get_user_connections(
+    pubkey: str,
+    observer: str | None = None,
+    kind: ConnectionKind = "following",
+    limit: int = DEFAULT_PAGE_SIZE,
+    cursor: str | None = None,
+    verified_threshold: float = DEFAULT_VERIFIED_THRESHOLD,
+) -> PaginatedUserConnections:
+    limit = max(1, min(limit, MAX_PAGE_SIZE))
+    rel_type, direction = _KIND_TO_REL[kind]
+    influence_key = f"influence_{observer}" if observer else f"influence_{pubkey}"
+    trusted_reporters_key = (
+        f"trusted_reporters_{observer}" if observer else f"trusted_reporters_{pubkey}"
+    )
+
+    cursor_inf, cursor_pk = (None, None)
+    if cursor:
+        try:
+            cursor_inf, cursor_pk = _decode_cursor(cursor)
+        except (ValueError, KeyError, TypeError, json.JSONDecodeError, binascii.Error):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="invalid cursor",
+            )
+    compute_stats = cursor is None
+
+    async with neo4j_driver.session() as session:
+        items, stats, last_cursor = await get_paginated_section_connections(
+            session,
+            pubkey=pubkey,
+            influence_key=influence_key,
+            trusted_reporters_key=trusted_reporters_key,
+            rel_type=rel_type,
+            direction=direction,
+            limit=limit,
+            cursor_inf=cursor_inf,
+            cursor_pk=cursor_pk,
+            compute_stats=compute_stats,
+            verified_threshold=verified_threshold,
+            tier_high=TIER_HIGH,
+            tier_trusted=TIER_TRUSTED,
+            tier_neutral=TIER_NEUTRAL,
+        )
+
+    # Sanitize NaN/Inf floats post-query for safe JSON encoding.
+    items = [
+        UserConnection(
+            pubkey=it.pubkey,
+            influence=_safe_float(it.influence),
+            trusted_reporters=it.trusted_reporters,
+        )
+        for it in items
+    ]
+
+    next_cursor: str | None = None
+    if last_cursor is not None:
+        last_sort_inf = _safe_float(last_cursor[0])
+        if last_sort_inf is not None:
+            next_cursor = _encode_cursor(last_sort_inf, last_cursor[1])
+
+    return PaginatedUserConnections(
+        items=items, next_cursor=next_cursor, stats=stats
     )
 
 


### PR DESCRIPTION
Split the `/user/{pubkey}` endpoints to deliver only necessary data in multiple sections.
- overview - initial "header" data and totals, pulled from redis
- stats - actual neo4j data with highly trusted, trusted, neutral, etc buckets
- individual sectors (connections) - paginated (cursor) list of users (200 default)

Note: section search, sort and filtering is client side only