### PR TITLE
Openranking impl

### DIFF
--- a/app/core/CLAUDE.md
+++ b/app/core/CLAUDE.md
@@ -23,7 +23,7 @@ This is the **only** module that should talk to Vespa. Everything else imports f
 |---|---|
 | `get_document(pubkey)` | Fetch a doc's fields by pubkey; `None` if 404. |
 | `upsert_profile(pubkey, profile)` | Partial-update kind-0 profile fields (`PROFILE_FIELDS`). Creates the doc if absent. Missing fields are cleared to `""`. |
-| `upsert_score(pubkey, observer, score)` | Insert/replace one cell of the `quality_scores` tensor. |
+| `upsert_score(pubkey, observer, score, followers)` | Insert/replace the observer's cell in BOTH the `quality_scores` (rank) and `follower_counts` (verified-follower count) tensors. |
 | `remove_score(pubkey, observer)` | Delete one tensor cell. 404s are silently ignored. |
 | `batch_upsert_scores(upserts, removes, observer)` | Fan out many `upsert_score`/`remove_score` calls concurrently (bounded by `_BATCH_CONCURRENCY = 32`). Returns `(n_ok, n_failed)`. Individual exceptions are caught + logged, never propagate. |
 | `search(query_text, user_pubkey, hits, include_zero_score_results)` | Multi-field search with the `text_relevance` (pure-text) rank profile. `user_pubkey` is the observer perspective (used by the trust-sorted rank_* profiles, not by the default). |

--- a/app/core/CLAUDE.md
+++ b/app/core/CLAUDE.md
@@ -26,7 +26,7 @@ This is the **only** module that should talk to Vespa. Everything else imports f
 | `upsert_score(pubkey, observer, score)` | Insert/replace one cell of the `quality_scores` tensor. |
 | `remove_score(pubkey, observer)` | Delete one tensor cell. 404s are silently ignored. |
 | `batch_upsert_scores(upserts, removes, observer)` | Fan out many `upsert_score`/`remove_score` calls concurrently (bounded by `_BATCH_CONCURRENCY = 32`). Returns `(n_ok, n_failed)`. Individual exceptions are caught + logged, never propagate. |
-| `search(query_text, user_pubkey, hits, include_zero_score_results)` | Multi-field search with the `name_and_quality_score_only` rank profile. `user_pubkey` is the observer perspective. |
+| `search(query_text, user_pubkey, hits, include_zero_score_results)` | Multi-field search with the `text_relevance` (pure-text) rank profile. `user_pubkey` is the observer perspective (used by the trust-sorted rank_* profiles, not by the default). |
 | `aclose()` | Close the shared httpx client. **Called from FastAPI lifespan shutdown** in `app/api.py`. |
 
 ### Shared client

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     block_frequent_graperank_requests_minutes: int = Field(default=30)
     periodic_graperank_pubkey: str = Field(default="")
     vespa_url: str = Field(...)
+    # Internal strfry relay used as the source of original signed kind-0 events
+    # for the NIP-50 /relay endpoint. Not exposed externally — the FastAPI
+    # /relay handler proxies search results out, never raw client traffic.
+    nip50_backing_relay_url: str = Field(default="ws://localhost:7777")
+    nip50_strfry_timeout_seconds: float = Field(default=3.0)
 
 
 settings = Settings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,6 +40,12 @@ class Settings(BaseSettings):
     # /relay handler proxies search results out, never raw client traffic.
     nip50_backing_relay_url: str = Field(default="ws://localhost:7777")
     nip50_strfry_timeout_seconds: float = Field(default=3.0)
+    # Open Ranking (ORE) auth posture. When True, every data endpoint requires
+    # a valid NWT (ORE-A) and answers ONLY from the signer's own observer
+    # perspective (a client-supplied `pov` is ignored). When False (default),
+    # the endpoints are open/unauthenticated and use the public global observer
+    # plus any client-supplied `pov` per ORE-01.
+    open_ranking_require_auth: bool = Field(default=False)
 
 
 settings = Settings()

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -524,16 +524,21 @@ async def search(
         # verified_followers is only in match-features for the sort_followers
         # profile; other profiles leave it None.
         fields["_followers"] = mf.get("verified_followers")
-        # match tier (doc.sd, §10/§11): name ladder exact>prefix>1-typo>2-typo,
-        # then "affiliation" (bio/website match) above "gram" (trigram/recall
-        # noise). Surfaced so the team can eyeball why a hit ranked where it did.
-        # None on the npub/hex direct-fetch path.
+        # match tier (doc.sd, §11): "name" (name/display/username/nip05 token
+        # match) > "affiliation" (about/website match) > "gram" (trigram/recall
+        # noise). The finer exact>prefix>typo name ladder (match_quality) is
+        # DEFERRED — itemRawScore doesn't populate for text terms, so it's always
+        # 0; we fall back to the reliable matchCount-based signals. `mf` is empty
+        # on the npub/hex direct-fetch path (no ranking ran).
         mq = mf.get("match_quality")
+        htm = mf.get("has_token_match")
         am = mf.get("affiliation_match")
         fields["_match_quality"] = mq
-        if mq is not None:
-            if int(mq) > 0:
+        if mf:
+            if mq and int(mq) > 0:
                 fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
+            elif htm:
+                fields["_match_tier"] = "name"
             elif am:
                 fields["_match_tier"] = "affiliation"
             else:

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -5,10 +5,12 @@ brainstorm_one_click_deployment/vespa-app) and uses a sparse tensor
 (`quality_scores`, keyed by observer pubkey) so each observer's ranking lives
 in its own cell of that tensor.
 
-The search function uses the `name_and_quality_score_only` rank profile:
+The search function uses the `text_relevance` rank profile (PURE TEXT — trust
+is not blended in; see docs/search-vs-tapestry.md §6):
 - name + display_name + about are searched
 - about partial matches via `about_gram` (trigrams)
 - single combined query + Vespa over-fetch for WAND-resistance
+The NIP-50 relay adds trust via the rank_* profiles (defaulting to rank_desc).
 """
 import asyncio
 import json
@@ -40,10 +42,11 @@ PROFILE_FIELDS = (
 MAX_QUERY_WORDS = 6
 
 # Rank-profile names defined in the Vespa schema (doc.sd). The default profile
-# blends text relevance with the observer's quality boost; the rank_* profiles
-# order by / filter on the observer's quality score for the NIP-50 sort:/filter:
-# extensions. See docs/search-precision-and-filtering.md (Problem 2).
-DEFAULT_RANK_PROFILE = "name_and_quality_score_only"
+# is PURE TEXT relevance (trust is not blended in) — /search/byText ranks on
+# text, mirroring tapestry/Meilisearch. The rank_* profiles add trust as a
+# sort/filter for the NIP-50 relay (which defaults to rank_desc). See
+# docs/search-vs-tapestry.md (§6) and docs/search-trust-vs-exact-match.md.
+DEFAULT_RANK_PROFILE = "text_relevance"
 RANK_PROFILE_FILTERED = "rank_filtered"
 RANK_PROFILE_SORT_DESC = "rank_desc"
 RANK_PROFILE_SORT_ASC = "rank_asc"

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -145,12 +145,29 @@ async def get_document(pubkey: str) -> dict | None:
     return r.json().get("fields")
 
 
+# Vespa string fields reject control characters — a kind-0 whose name is a
+# literal NUL (\x00) gets a 400 ("illegal code point 0x0"). Strip the C0 control set
+# (and DEL) except tab/newline/CR so the profile indexes cleaned instead of
+# failing the upsert. Applies to BOTH the live ingest path and the kind-0
+# re-feed backfill (scripts/refeed_kind0_to_vespa.py).
+_BAD_CHARS: dict[int, None] = {
+    c: None for c in range(0x20) if c not in (0x09, 0x0A, 0x0D)
+}
+_BAD_CHARS[0x7F] = None
+
+
+def _clean(value: str) -> str:
+    """Drop control characters Vespa string fields reject."""
+    return value.translate(_BAD_CHARS)
+
+
 async def upsert_profile(pubkey: str, profile: dict) -> None:
     """Partial-update profile fields for a doc, creating it if absent.
 
     For every standard kind-0 field we either assign the provided value or
     clear it with an empty string when the new event doesn't include it, so
-    the prior value is replaced rather than left stale.
+    the prior value is replaced rather than left stale. String values are
+    stripped of control characters Vespa rejects (see `_clean`).
     """
     fields_payload: dict = {"pubkey": {"assign": pubkey}}
     for f in PROFILE_FIELDS:
@@ -160,9 +177,9 @@ async def upsert_profile(pubkey: str, profile: dict) -> None:
         if v is None:
             fields_payload[f] = {"assign": ""}
         elif isinstance(v, str):
-            fields_payload[f] = {"assign": v}
+            fields_payload[f] = {"assign": _clean(v)}
         else:
-            fields_payload[f] = {"assign": str(v)}
+            fields_payload[f] = {"assign": _clean(str(v))}
 
     body = {"fields": fields_payload}
     # PUT (not POST) is Vespa's partial-update verb: assign/add/remove ops live

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -30,7 +30,6 @@ DOCTYPE = "doc"
 PROFILE_FIELDS = (
     "name",
     "display_name",
-    "username",
     "about",
     "picture",
     "banner",
@@ -370,7 +369,7 @@ async def search(
         # verified_followers is only in match-features for the sort_followers
         # profile; other profiles leave it None.
         fields["_followers"] = mf.get("verified_followers")
-        # match tier (doc.sd §11/§12): "name" (name/display/username token match) >
+        # match tier (doc.sd §11/§12): "name" (name/display_name token match) >
         # "identity" (nip05/lud16, IDF-scored — the "primal" dilution) >
         # "affiliation" (about/website) > "gram" (trigram/recall noise). The
         # default profile also multiplies text by trust (wot_mult) and IDF-scores

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -39,6 +39,15 @@ PROFILE_FIELDS = (
 # How many query words we label / parametrize at most.
 MAX_QUERY_WORDS = 6
 
+# Rank-profile names defined in the Vespa schema (doc.sd). The default profile
+# blends text relevance with the observer's quality boost; the rank_* profiles
+# order by / filter on the observer's quality score for the NIP-50 sort:/filter:
+# extensions. See docs/search-precision-and-filtering.md (Problem 2).
+DEFAULT_RANK_PROFILE = "name_and_quality_score_only"
+RANK_PROFILE_FILTERED = "rank_filtered"
+RANK_PROFILE_SORT_DESC = "rank_desc"
+RANK_PROFILE_SORT_ASC = "rank_asc"
+
 # Bounded concurrency for batch score upserts. Vespa's container can handle a
 # lot more than this — the limit is mostly to keep retry/backoff predictable.
 _BATCH_CONCURRENCY = 32
@@ -276,6 +285,9 @@ def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
         f'({{defaultIndex:"{field}",prefix:true}}userInput({var}))',
     ]
     if max_edits > 0:
+        # prefixLength:2 — the first two characters must match exactly, so a
+        # typo in char >=3 is corrected but a wrong first/second letter no
+        # longer drags in unrelated names. See the precision doc (Problem 1).
         parts.append(
             f'({{defaultIndex:"{field}",fuzzy:{{maxEditDistance:{max_edits},prefixLength:2}}}}userInput({var}))'
         )
@@ -285,9 +297,6 @@ def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
 def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
     """All match clauses for one query word across name/display_name/about + grams."""
     me = _word_max_edits(literal)
-        # prefixLength:2 — the first two characters must match exactly, so a
-        # typo in char >=3 is corrected but a wrong first/second letter no
-        # longer drags in unrelated names. See the precision doc (Problem 1).
     clauses: list[str] = []
     for field in ("name", "display_name", "about"):
         clauses += _field_clauses(field, var, me)
@@ -323,12 +332,22 @@ async def search(
     user_pubkey: str,
     hits: int = 100,
     include_zero_score_results: bool = True,
+    *,
+    ranking_profile: str | None = None,
+    min_rank: float | None = None,
 ) -> list[dict]:
-    """Multi-field search using the `name_and_quality_score_only` rank profile.
+    """Multi-field search against a quality-score rank profile.
 
     `user_pubkey` is the observer perspective whose quality_score is used for
     ranking. Returns a list of dicts, each merging the doc's stored fields with
     `_relevance` and a `_quality_score` (the observer's score for that doc).
+
+    `ranking_profile` selects the Vespa rank profile (defaults to
+    `DEFAULT_RANK_PROFILE`); pass one of the `RANK_PROFILE_*` constants to order
+    by / filter on the observer's quality score. `min_rank`, when set, is passed
+    as `query(min_rank)` so the rank_* profiles drop hits whose quality score is
+    below it (the NIP-50 `filter:rank:gte/gt` push-down). Both are no-ops on the
+    default profile. See docs/search-precision-and-filtering.md (Problem 2).
     """
     words = query_text.split()[:MAX_QUERY_WORDS]
     joined = "".join(words) if len(words) >= 2 else None
@@ -346,13 +365,15 @@ async def search(
 
     params = {
         "yql": _build_yql(words, joined),
-        "ranking": "name_and_quality_score_only",
+        "ranking": ranking_profile or DEFAULT_RANK_PROFILE,
         "ranking.features.query(user_q)": "{" + user_pubkey + ":1.0}",
         "ranking.features.query(w_gram)": w_gram,
         "ranking.features.query(w_about)": 0.5,
         "ranking.features.query(w_about_bonus)": 0.0,
         "hits": vespa_hits,
     }
+    if min_rank is not None:
+        params["ranking.features.query(min_rank)"] = min_rank
     for i, w in enumerate(words):
         params[f"w{i}"] = w
     if joined:

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -42,10 +42,10 @@ PROFILE_FIELDS = (
 # How many query words we label / parametrize at most.
 MAX_QUERY_WORDS = 6
 
-# Maps the doc.sd match_quality() tier (0..4) to a human label surfaced in the
-# search response as `_match_tier`, so the team can eyeball exact-vs-typo tiers
-# without raw Vespa queries. See docs/search-vs-tapestry.md §10.
-_MATCH_TIERS = {4: "exact", 3: "prefix", 2: "1-typo", 1: "2-typo", 0: "gram"}
+# Maps the doc.sd match_quality() name tier (1..4) to a human label surfaced in
+# the search response as `_match_tier`. Tier 0 resolves to "affiliation" (bio or
+# website domain match) or "gram" (trigram/recall noise). See §10 / §11.
+_MATCH_TIERS = {4: "exact", 3: "prefix", 2: "1-typo", 1: "2-typo"}
 
 # Rank-profile names defined in the Vespa schema (doc.sd). The DEFAULT is
 # `sort_followers`: text match, filter rank >= query(min_rank), sort by the
@@ -340,39 +340,60 @@ def _word_max_edits(word: str) -> int:
     return 0
 
 
-# Fields whose exact/prefix/fuzzy match feeds the match-quality tier
-# (match_quality / has_token_match in doc.sd). Bios + payment/website fields are
-# recall-only, so a hit there must NOT promote a doc into the name-match tier.
+# Field roles for match labeling (consumed by match_quality / affiliation_match
+# in doc.sd via itemRawScore):
+#   primary     — name/display_name/username/nip05 → exact>prefix>1-typo>2-typo
+#   affiliation — bio + website → only the EXACT-token match is labeled
+#                 (mtch_affil), driving the affiliation tier (below name matches,
+#                 above gram noise). "related to X" signals: a bio mentioning X,
+#                 or an account whose own website domain is X.
+#   recall      — lud16 → unlabeled, pure recall
+# NB website is a URL: default linguistics splits "odell.com" -> [odell, com]
+# (exact "odell" hits) but "citadeldispatch.com" -> [citadeldispatch, com]
+# (exact "citadel" misses — would need prefix). See §11.
 _PRIMARY_FIELDS = ("name", "display_name", "username", "nip05")
+_AFFILIATION_FIELDS = ("about", "website")
 
 
-def _field_clauses(field: str, var: str, max_edits: int, primary: bool) -> list[str]:
+def _field_role(field: str) -> str:
+    if field in _PRIMARY_FIELDS:
+        return "primary"
+    if field in _AFFILIATION_FIELDS:
+        return "affiliation"
+    return "recall"
+
+
+def _field_clauses(field: str, var: str, max_edits: int, role: str) -> list[str]:
     """Match clauses for one (field, word): exact, prefix, and up to two fuzzy
-    tiers. On PRIMARY fields each variant is labeled so the rank profile can
-    build an exact > prefix > 1-typo > 2-typo ladder via itemRawScore()
-    (match_quality, doc.sd) — mirroring Meilisearch's `typo` ranking bucket.
-    Recall-only fields stay unlabeled so a bio/website hit doesn't jump tiers.
+    tiers. Labels depend on the field `role` so the rank profile can build the
+    exact>prefix>1-typo>2-typo name ladder (match_quality) AND the affiliation
+    tier (affiliation_match), both via itemRawScore(). Recall fields stay
+    unlabeled so a hit there can't jump tiers. See docs §10 / §11.
     """
-    def _ann(extra: list[str], label: str) -> str:
+    def _ann(extra: list[str], label: str | None) -> str:
         ann = [f'defaultIndex:"{field}"'] + extra
-        if primary:
+        if label:
             ann.append(f'label:"{label}"')
         return "{" + ",".join(ann) + "}"
 
+    ex_label = {"primary": "mtch_exact", "affiliation": "mtch_affil"}.get(role)
+    pf_label = "mtch_prefix" if role == "primary" else None
     clauses = [
-        f"({_ann([], 'mtch_exact')}userInput({var}))",
-        f"({_ann(['prefix:true'], 'mtch_prefix')}userInput({var}))",
+        f"({_ann([], ex_label)}userInput({var}))",
+        f"({_ann(['prefix:true'], pf_label)}userInput({var}))",
     ]
     # prefixLength:2 — the first two characters must match exactly, so a typo in
     # char >=3 is corrected but a wrong first/second letter no longer drags in
     # unrelated names. Separate fz1/fz2 labels so 1-typo outranks 2-typo.
     if max_edits >= 1:
+        fz1 = "mtch_fz1" if role == "primary" else None
         clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], 'mtch_fz1')}userInput({var}))"
+            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], fz1)}userInput({var}))"
         )
     if max_edits >= 2:
+        fz2 = "mtch_fz2" if role == "primary" else None
         clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], 'mtch_fz2')}userInput({var}))"
+            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], fz2)}userInput({var}))"
         )
     return clauses
 
@@ -388,7 +409,7 @@ def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
     me = _word_max_edits(literal)
     clauses: list[str] = []
     for field in ("name", "display_name", "about", "username", "nip05", "lud16", "website"):
-        clauses += _field_clauses(field, var, me, field in _PRIMARY_FIELDS)
+        clauses += _field_clauses(field, var, me, _field_role(field))
     if with_grams:
         for gram_field in ("name_gram", "display_name_gram"):
             gc = _gram_clause(literal, gram_field)
@@ -503,12 +524,19 @@ async def search(
         # verified_followers is only in match-features for the sort_followers
         # profile; other profiles leave it None.
         fields["_followers"] = mf.get("verified_followers")
-        # match_quality is the exact>prefix>1-typo>2-typo tier (doc.sd, §10);
-        # surface the raw int + a human label so the team can eyeball why a hit
-        # ranked where it did. None on the npub/hex direct-fetch path.
+        # match tier (doc.sd, §10/§11): name ladder exact>prefix>1-typo>2-typo,
+        # then "affiliation" (bio/website match) above "gram" (trigram/recall
+        # noise). Surfaced so the team can eyeball why a hit ranked where it did.
+        # None on the npub/hex direct-fetch path.
         mq = mf.get("match_quality")
+        am = mf.get("affiliation_match")
         fields["_match_quality"] = mq
         if mq is not None:
-            fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
+            if int(mq) > 0:
+                fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
+            elif am:
+                fields["_match_tier"] = "affiliation"
+            else:
+                fields["_match_tier"] = "gram"
         out.append(fields)
     return out

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -258,8 +258,16 @@ def _about_gram_clause_for_word(word: str, gram_size: int = 3) -> str:
 
 
 def _word_max_edits(word: str) -> int:
-    """Per-word fuzzy budget — 0 for very short words, up to 2 for longer ones."""
-    return 0 if len(word) < 3 else (1 if len(word) < 6 else 2)
+    """Per-word fuzzy budget. Capped at a single edit, and only for words long
+    enough that a 1-char typo is plausible rather than a different word.
+
+    We deliberately do NOT allow 2 edits: at distance 2 the candidate set
+    explodes (an 8-char name matches hundreds of unrelated names) and, because
+    Vespa's matchCount() counts a fuzzy match the same as an exact one, those
+    neighbours score identically to genuine matches — which is what made exact
+    matching "suffer". See docs/search-precision-and-filtering.md (Problem 1).
+    """
+    return 1 if len(word) >= 4 else 0
 
 
 def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
@@ -269,7 +277,7 @@ def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
     ]
     if max_edits > 0:
         parts.append(
-            f'({{defaultIndex:"{field}",fuzzy:{{maxEditDistance:{max_edits},prefixLength:1}}}}userInput({var}))'
+            f'({{defaultIndex:"{field}",fuzzy:{{maxEditDistance:{max_edits},prefixLength:2}}}}userInput({var}))'
         )
     return parts
 
@@ -277,6 +285,9 @@ def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
 def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
     """All match clauses for one query word across name/display_name/about + grams."""
     me = _word_max_edits(literal)
+        # prefixLength:2 — the first two characters must match exactly, so a
+        # typo in char >=3 is corrected but a wrong first/second letter no
+        # longer drags in unrelated names. See the precision doc (Problem 1).
     clauses: list[str] = []
     for field in ("name", "display_name", "about"):
         clauses += _field_clauses(field, var, me)
@@ -322,7 +333,11 @@ async def search(
     words = query_text.split()[:MAX_QUERY_WORDS]
     joined = "".join(words) if len(words) >= 2 else None
     shortest = min((len(w) for w in words), default=len(query_text))
-    w_gram = 20.0 if shortest <= 3 else 5.0
+    # Trigrams are a recall safety-net + tie-breaker, not a primary ranker.
+    # Keep them meaningful for very short queries (where token matching barely
+    # fires) but well below an exact token match otherwise. The schema also
+    # caps the per-field gram contribution via query(gram_cap). See Problem 1.
+    w_gram = 8.0 if shortest <= 3 else 2.0
 
     vespa_hits = max(hits, 20)
     if not include_zero_score_results:

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -42,6 +42,11 @@ PROFILE_FIELDS = (
 # How many query words we label / parametrize at most.
 MAX_QUERY_WORDS = 6
 
+# Maps the doc.sd match_quality() tier (0..4) to a human label surfaced in the
+# search response as `_match_tier`, so the team can eyeball exact-vs-typo tiers
+# without raw Vespa queries. See docs/search-vs-tapestry.md §10.
+_MATCH_TIERS = {4: "exact", 3: "prefix", 2: "1-typo", 1: "2-typo", 0: "gram"}
+
 # Rank-profile names defined in the Vespa schema (doc.sd). The DEFAULT is
 # `sort_followers`: text match, filter rank >= query(min_rank), sort by the
 # observer's verified-follower count (popular-first). The other profiles are
@@ -318,31 +323,58 @@ def _about_gram_clause_for_word(word: str, gram_size: int = 3) -> str:
 
 
 def _word_max_edits(word: str) -> int:
-    """Per-word fuzzy budget. Capped at a single edit, and only for words long
-    enough that a 1-char typo is plausible rather than a different word.
+    """Per-word fuzzy budget, length-gated like Meilisearch: <4 → exact/prefix
+    only, ≥4 → 1 edit, ≥9 → 2 edits.
 
-    We deliberately do NOT allow 2 edits: at distance 2 the candidate set
-    explodes (an 8-char name matches hundreds of unrelated names) and, because
-    Vespa's matchCount() counts a fuzzy match the same as an exact one, those
-    neighbours score identically to genuine matches — which is what made exact
-    matching "suffer". See docs/search-precision-and-filtering.md (Problem 1).
+    Two edits is safe now that the rank profile tiers exact > prefix > 1-typo >
+    2-typo (match_quality in doc.sd, via the labels added in `_field_clauses`):
+    a 2-edit neighbour lands in the lowest match tier instead of scoring like an
+    exact hit, which is what made wider fuzzy "suffer" before. See
+    docs/search-precision-and-filtering.md (Problem 1) and the §10 typo
+    deep-dive in docs/search-vs-tapestry.md.
     """
-    return 1 if len(word) >= 4 else 0
+    if len(word) >= 9:
+        return 2
+    if len(word) >= 4:
+        return 1
+    return 0
 
 
-def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
-    parts = [
-        f'({{defaultIndex:"{field}"}}userInput({var}))',
-        f'({{defaultIndex:"{field}",prefix:true}}userInput({var}))',
+# Fields whose exact/prefix/fuzzy match feeds the match-quality tier
+# (match_quality / has_token_match in doc.sd). Bios + payment/website fields are
+# recall-only, so a hit there must NOT promote a doc into the name-match tier.
+_PRIMARY_FIELDS = ("name", "display_name", "username", "nip05")
+
+
+def _field_clauses(field: str, var: str, max_edits: int, primary: bool) -> list[str]:
+    """Match clauses for one (field, word): exact, prefix, and up to two fuzzy
+    tiers. On PRIMARY fields each variant is labeled so the rank profile can
+    build an exact > prefix > 1-typo > 2-typo ladder via itemRawScore()
+    (match_quality, doc.sd) — mirroring Meilisearch's `typo` ranking bucket.
+    Recall-only fields stay unlabeled so a bio/website hit doesn't jump tiers.
+    """
+    def _ann(extra: list[str], label: str) -> str:
+        ann = [f'defaultIndex:"{field}"'] + extra
+        if primary:
+            ann.append(f'label:"{label}"')
+        return "{" + ",".join(ann) + "}"
+
+    clauses = [
+        f"({_ann([], 'mtch_exact')}userInput({var}))",
+        f"({_ann(['prefix:true'], 'mtch_prefix')}userInput({var}))",
     ]
-    if max_edits > 0:
-        # prefixLength:2 — the first two characters must match exactly, so a
-        # typo in char >=3 is corrected but a wrong first/second letter no
-        # longer drags in unrelated names. See the precision doc (Problem 1).
-        parts.append(
-            f'({{defaultIndex:"{field}",fuzzy:{{maxEditDistance:{max_edits},prefixLength:2}}}}userInput({var}))'
+    # prefixLength:2 — the first two characters must match exactly, so a typo in
+    # char >=3 is corrected but a wrong first/second letter no longer drags in
+    # unrelated names. Separate fz1/fz2 labels so 1-typo outranks 2-typo.
+    if max_edits >= 1:
+        clauses.append(
+            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], 'mtch_fz1')}userInput({var}))"
         )
-    return parts
+    if max_edits >= 2:
+        clauses.append(
+            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], 'mtch_fz2')}userInput({var}))"
+        )
+    return clauses
 
 
 def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
@@ -350,13 +382,13 @@ def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
 
     name/display_name/about are the primary text signal (and feed the rank
     profile's text functions). username/nip05 also feed the match-quality tier
-    (has_token_match in doc.sd). lud16/website are recall-only (P1). See
+    (match_quality in doc.sd). lud16/website are recall-only (P1). See
     docs/search-vs-tapestry.md §8.4.
     """
     me = _word_max_edits(literal)
     clauses: list[str] = []
     for field in ("name", "display_name", "about", "username", "nip05", "lud16", "website"):
-        clauses += _field_clauses(field, var, me)
+        clauses += _field_clauses(field, var, me, field in _PRIMARY_FIELDS)
     if with_grams:
         for gram_field in ("name_gram", "display_name_gram"):
             gc = _gram_clause(literal, gram_field)
@@ -368,16 +400,18 @@ def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
     return "(" + " or ".join(clauses) + ")"
 
 
-def _build_yql(words: list[str], joined: str | None) -> str:
+def _build_yql(words: list[str], joined: str | None, pairs: list[str]) -> str:
     """Per-word groups OR'd together, plus an optional joined-CamelCase variant
     (whole-token only) so a query like 'vitor pamplona' still hits a doc named
-    'VitorPamplona'."""
+    'VitorPamplona', plus adjacent-pair concatenations for >2-word queries."""
     parts = [
         _word_group(f"@w{i}", w)
         for i, w in enumerate(words[:MAX_QUERY_WORDS])
     ]
     if joined:
         parts.append(_word_group("@wj", joined, with_grams=False))
+    for i, _ in enumerate(pairs):
+        parts.append(_word_group(f"@wp{i}", pairs[i], with_grams=False))
     return f"select * from doc where {' or '.join(parts)}"
 
 
@@ -408,6 +442,15 @@ async def search(
     """
     words = query_text.split()[:MAX_QUERY_WORDS]
     joined = "".join(words) if len(words) >= 2 else None
+    # Adjacent-pair concatenations ("nos fabrica" -> "nosfabrica") for queries
+    # with >2 words, where the whole-string join (`joined`) wouldn't match a
+    # 2-token name. 2-word queries are already covered by `joined`. Whole-token
+    # only (no grams). See the §10 typo deep-dive (word-boundary handling).
+    pairs = (
+        ["".join(words[i:i + 2]) for i in range(len(words) - 1)]
+        if len(words) >= 3
+        else []
+    )
     shortest = min((len(w) for w in words), default=len(query_text))
     # Trigrams are a recall safety-net + tie-breaker, not a primary ranker.
     # Keep them meaningful for very short queries (where token matching barely
@@ -421,7 +464,7 @@ async def search(
     vespa_hits = min(vespa_hits, 400)  # Vespa default max-hits
 
     params = {
-        "yql": _build_yql(words, joined),
+        "yql": _build_yql(words, joined, pairs),
         "ranking": ranking_profile or DEFAULT_RANK_PROFILE,
         "ranking.features.query(user_q)": "{" + user_pubkey + ":1.0}",
         "ranking.features.query(w_gram)": w_gram,
@@ -435,6 +478,8 @@ async def search(
         params[f"w{i}"] = w
     if joined:
         params["wj"] = joined
+    for i, p in enumerate(pairs):
+        params[f"wp{i}"] = p
 
     r = await _get_client().get(f"{settings.vespa_url}/search/", params=params)
     r.raise_for_status()
@@ -458,5 +503,12 @@ async def search(
         # verified_followers is only in match-features for the sort_followers
         # profile; other profiles leave it None.
         fields["_followers"] = mf.get("verified_followers")
+        # match_quality is the exact>prefix>1-typo>2-typo tier (doc.sd, §10);
+        # surface the raw int + a human label so the team can eyeball why a hit
+        # ranked where it did. None on the npub/hex direct-fetch path.
+        mq = mf.get("match_quality")
+        fields["_match_quality"] = mq
+        if mq is not None:
+            fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
         out.append(fields)
     return out

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -19,6 +19,7 @@ import httpx
 
 from app.core.config import settings
 from app.core.loggr import loggr
+from app.core.vespa_query import MAX_QUERY_WORDS, build_query
 
 logger = loggr.get_logger(__name__)
 
@@ -38,9 +39,6 @@ PROFILE_FIELDS = (
     "lud16",
     "website",
 )
-
-# How many query words we label / parametrize at most.
-MAX_QUERY_WORDS = 6
 
 # Maps the doc.sd match_quality() name tier (1..4) to a human label surfaced in
 # the search response as `_match_tier`. Tier 0 resolves to "affiliation" (bio or
@@ -292,148 +290,10 @@ async def batch_upsert_scores(
 
 
 # ---------------------------------------------------------------------------
-# YQL builders (ported from the search_quality prototype)
+# YQL builders live in app/core/vespa_query.py (stdlib-only) so diagnostic
+# tooling (scripts/analyze_pubkey.py) can build the EXACT same query without
+# importing settings/httpx. search() below calls build_query() from there.
 # ---------------------------------------------------------------------------
-def _gram_clause(text: str, gram_field: str, gram_size: int = 3) -> str:
-    """OR of every trigram in `text` against `gram_field`."""
-    grams = set()
-    for word in text.lower().split():
-        for i in range(max(1, len(word) - gram_size + 1)):
-            g = word[i : i + gram_size]
-            if len(g) == gram_size and g.isalnum():
-                grams.add(g)
-    if not grams:
-        return ""
-    return (
-        "(" + " or ".join(f'{gram_field} contains "{g}"' for g in sorted(grams)) + ")"
-    )
-
-
-def _about_gram_clause_for_word(word: str, gram_size: int = 3) -> str:
-    """AND of one word's trigrams against `about_gram` (discriminative)."""
-    grams = [
-        word[i : i + gram_size]
-        for i in range(len(word) - gram_size + 1)
-        if word[i : i + gram_size].isalnum()
-        and len(word[i : i + gram_size]) == gram_size
-    ]
-    if not grams:
-        return ""
-    return "(" + " and ".join(f'about_gram contains "{g}"' for g in grams) + ")"
-
-
-def _word_max_edits(word: str) -> int:
-    """Per-word fuzzy budget, length-gated like Meilisearch: <4 → exact/prefix
-    only, ≥4 → 1 edit, ≥9 → 2 edits.
-
-    Two edits is safe now that the rank profile tiers exact > prefix > 1-typo >
-    2-typo (match_quality in doc.sd, via the labels added in `_field_clauses`):
-    a 2-edit neighbour lands in the lowest match tier instead of scoring like an
-    exact hit, which is what made wider fuzzy "suffer" before. See
-    docs/search-precision-and-filtering.md (Problem 1) and the §10 typo
-    deep-dive in docs/search-vs-tapestry.md.
-    """
-    if len(word) >= 9:
-        return 2
-    if len(word) >= 4:
-        return 1
-    return 0
-
-
-# Field roles for match labeling (consumed by match_quality / affiliation_match
-# in doc.sd via itemRawScore):
-#   primary     — name/display_name/username/nip05 → exact>prefix>1-typo>2-typo
-#   affiliation — bio + website → only the EXACT-token match is labeled
-#                 (mtch_affil), driving the affiliation tier (below name matches,
-#                 above gram noise). "related to X" signals: a bio mentioning X,
-#                 or an account whose own website domain is X.
-#   recall      — lud16 → unlabeled, pure recall
-# NB website is a URL: default linguistics splits "odell.com" -> [odell, com]
-# (exact "odell" hits) but "citadeldispatch.com" -> [citadeldispatch, com]
-# (exact "citadel" misses — would need prefix). See §11.
-_PRIMARY_FIELDS = ("name", "display_name", "username", "nip05")
-_AFFILIATION_FIELDS = ("about", "website")
-
-
-def _field_role(field: str) -> str:
-    if field in _PRIMARY_FIELDS:
-        return "primary"
-    if field in _AFFILIATION_FIELDS:
-        return "affiliation"
-    return "recall"
-
-
-def _field_clauses(field: str, var: str, max_edits: int, role: str) -> list[str]:
-    """Match clauses for one (field, word): exact, prefix, and up to two fuzzy
-    tiers. Labels depend on the field `role` so the rank profile can build the
-    exact>prefix>1-typo>2-typo name ladder (match_quality) AND the affiliation
-    tier (affiliation_match), both via itemRawScore(). Recall fields stay
-    unlabeled so a hit there can't jump tiers. See docs §10 / §11.
-    """
-    def _ann(extra: list[str], label: str | None) -> str:
-        ann = [f'defaultIndex:"{field}"'] + extra
-        if label:
-            ann.append(f'label:"{label}"')
-        return "{" + ",".join(ann) + "}"
-
-    ex_label = {"primary": "mtch_exact", "affiliation": "mtch_affil"}.get(role)
-    pf_label = "mtch_prefix" if role == "primary" else None
-    clauses = [
-        f"({_ann([], ex_label)}userInput({var}))",
-        f"({_ann(['prefix:true'], pf_label)}userInput({var}))",
-    ]
-    # prefixLength:2 — the first two characters must match exactly, so a typo in
-    # char >=3 is corrected but a wrong first/second letter no longer drags in
-    # unrelated names. Separate fz1/fz2 labels so 1-typo outranks 2-typo.
-    if max_edits >= 1:
-        fz1 = "mtch_fz1" if role == "primary" else None
-        clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], fz1)}userInput({var}))"
-        )
-    if max_edits >= 2:
-        fz2 = "mtch_fz2" if role == "primary" else None
-        clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], fz2)}userInput({var}))"
-        )
-    return clauses
-
-
-def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
-    """All match clauses for one query word across the searchable fields + grams.
-
-    name/display_name/about are the primary text signal (and feed the rank
-    profile's text functions). username/nip05 also feed the match-quality tier
-    (match_quality in doc.sd). lud16/website are recall-only (P1). See
-    docs/search-vs-tapestry.md §8.4.
-    """
-    me = _word_max_edits(literal)
-    clauses: list[str] = []
-    for field in ("name", "display_name", "about", "username", "nip05", "lud16", "website"):
-        clauses += _field_clauses(field, var, me, _field_role(field))
-    if with_grams:
-        for gram_field in ("name_gram", "display_name_gram"):
-            gc = _gram_clause(literal, gram_field)
-            if gc:
-                clauses.append(gc)
-        agc = _about_gram_clause_for_word(literal)
-        if agc:
-            clauses.append(agc)
-    return "(" + " or ".join(clauses) + ")"
-
-
-def _build_yql(words: list[str], joined: str | None, pairs: list[str]) -> str:
-    """Per-word groups OR'd together, plus an optional joined-CamelCase variant
-    (whole-token only) so a query like 'vitor pamplona' still hits a doc named
-    'VitorPamplona', plus adjacent-pair concatenations for >2-word queries."""
-    parts = [
-        _word_group(f"@w{i}", w)
-        for i, w in enumerate(words[:MAX_QUERY_WORDS])
-    ]
-    if joined:
-        parts.append(_word_group("@wj", joined, with_grams=False))
-    for i, _ in enumerate(pairs):
-        parts.append(_word_group(f"@wp{i}", pairs[i], with_grams=False))
-    return f"select * from doc where {' or '.join(parts)}"
 
 
 # ---------------------------------------------------------------------------
@@ -461,17 +321,8 @@ async def search(
     below it (the NIP-50 `filter:rank:gte/gt` push-down). Both are no-ops on the
     default profile. See docs/search-precision-and-filtering.md (Problem 2).
     """
-    words = query_text.split()[:MAX_QUERY_WORDS]
-    joined = "".join(words) if len(words) >= 2 else None
-    # Adjacent-pair concatenations ("nos fabrica" -> "nosfabrica") for queries
-    # with >2 words, where the whole-string join (`joined`) wouldn't match a
-    # 2-token name. 2-word queries are already covered by `joined`. Whole-token
-    # only (no grams). See the §10 typo deep-dive (word-boundary handling).
-    pairs = (
-        ["".join(words[i:i + 2]) for i in range(len(words) - 1)]
-        if len(words) >= 3
-        else []
-    )
+    # Build the YQL + per-word params (shared with scripts/analyze_pubkey.py).
+    words, yql, word_params = build_query(query_text)
     shortest = min((len(w) for w in words), default=len(query_text))
     # Trigrams are a recall safety-net + tie-breaker, not a primary ranker.
     # Keep them meaningful for very short queries (where token matching barely
@@ -485,7 +336,7 @@ async def search(
     vespa_hits = min(vespa_hits, 400)  # Vespa default max-hits
 
     params = {
-        "yql": _build_yql(words, joined, pairs),
+        "yql": yql,
         "ranking": ranking_profile or DEFAULT_RANK_PROFILE,
         "ranking.features.query(user_q)": "{" + user_pubkey + ":1.0}",
         "ranking.features.query(w_gram)": w_gram,
@@ -495,12 +346,7 @@ async def search(
     }
     if min_rank is not None:
         params["ranking.features.query(min_rank)"] = min_rank
-    for i, w in enumerate(words):
-        params[f"w{i}"] = w
-    if joined:
-        params["wj"] = joined
-    for i, p in enumerate(pairs):
-        params[f"wp{i}"] = p
+    params.update(word_params)
 
     r = await _get_client().get(f"{settings.vespa_url}/search/", params=params)
     r.raise_for_status()

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -370,22 +370,28 @@ async def search(
         # verified_followers is only in match-features for the sort_followers
         # profile; other profiles leave it None.
         fields["_followers"] = mf.get("verified_followers")
-        # match tier (doc.sd, §11): "name" (name/display/username/nip05 token
-        # match) > "affiliation" (about/website match) > "gram" (trigram/recall
-        # noise). The finer exact>prefix>typo name ladder (match_quality) is
-        # DEFERRED — itemRawScore doesn't populate for text terms, so it's always
-        # 0; we fall back to the reliable matchCount-based signals. `mf` is empty
-        # on the npub/hex direct-fetch path (no ranking ran).
+        # match tier (doc.sd §11/§12): "name" (name/display/username token match) >
+        # "identity" (nip05/lud16, IDF-scored — the "primal" dilution) >
+        # "affiliation" (about/website) > "gram" (trigram/recall noise). The
+        # default profile also multiplies text by trust (wot_mult) and IDF-scores
+        # identity fields (identity_text) — both surfaced below for the inspector.
+        # `mf` is empty on the npub/hex direct-fetch path (no ranking ran).
         mq = mf.get("match_quality")
-        htm = mf.get("has_token_match")
-        am = mf.get("affiliation_match")
         fields["_match_quality"] = mq
+        fields["_identity_text"] = mf.get("identity_text")
+        fields["_text_score"] = mf.get("text_score")
+        fields["_wot_mult"] = mf.get("wot_mult")
         if mf:
             if mq and int(mq) > 0:
                 fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
-            elif htm:
+            elif mf.get("name_match"):
                 fields["_match_tier"] = "name"
-            elif am:
+            elif mf.get("identity_match"):
+                fields["_match_tier"] = "identity"
+            elif mf.get("has_token_match"):
+                # older profiles fold nip05/lud16 into has_token_match
+                fields["_match_tier"] = "name"
+            elif mf.get("affiliation_match"):
                 fields["_match_tier"] = "affiliation"
             else:
                 fields["_match_tier"] = "gram"

--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -29,6 +29,7 @@ DOCTYPE = "doc"
 PROFILE_FIELDS = (
     "name",
     "display_name",
+    "username",
     "about",
     "picture",
     "banner",
@@ -41,15 +42,31 @@ PROFILE_FIELDS = (
 # How many query words we label / parametrize at most.
 MAX_QUERY_WORDS = 6
 
-# Rank-profile names defined in the Vespa schema (doc.sd). The default profile
-# is PURE TEXT relevance (trust is not blended in) — /search/byText ranks on
-# text, mirroring tapestry/Meilisearch. The rank_* profiles add trust as a
-# sort/filter for the NIP-50 relay (which defaults to rank_desc). See
-# docs/search-vs-tapestry.md (§6) and docs/search-trust-vs-exact-match.md.
-DEFAULT_RANK_PROFILE = "text_relevance"
+# Rank-profile names defined in the Vespa schema (doc.sd). The DEFAULT is
+# `sort_followers`: text match, filter rank >= query(min_rank), sort by the
+# observer's verified-follower count (popular-first). The other profiles are
+# the configurable sort alternates (rank / text). All gate on query(min_rank)
+# except text_relevance. See docs/search-vs-tapestry.md §8.
+DEFAULT_RANK_PROFILE = "sort_followers"
+RANK_PROFILE_SORT_FOLLOWERS = "sort_followers"
 RANK_PROFILE_FILTERED = "rank_filtered"
 RANK_PROFILE_SORT_DESC = "rank_desc"
 RANK_PROFILE_SORT_ASC = "rank_asc"
+RANK_PROFILE_TEXT = "text_relevance"
+
+# Maps a public `sort=` value (byText) / NIP-50 sort metric to a rank profile.
+# `followers` is the default; `rank` orders by trust; `text` is pure relevance.
+SORT_PROFILES = {
+    "followers": RANK_PROFILE_SORT_FOLLOWERS,
+    "rank": RANK_PROFILE_SORT_DESC,
+    "text": RANK_PROFILE_FILTERED,
+}
+
+# Default query-time trust filter: exclude rank < this (rank = influence*100).
+# Product default is "exclude based on rank 2" (docs/search-vs-tapestry.md §8.1);
+# configurable per request. The sort_followers/rank_* profiles gate on
+# query(min_rank); text_relevance ignores it.
+DEFAULT_MIN_RANK = 2.0
 
 # Bounded concurrency for batch score upserts. Vespa's container can handle a
 # lot more than this — the limit is mostly to keep retry/backoff predictable.
@@ -158,11 +175,15 @@ async def upsert_profile(pubkey: str, profile: dict) -> None:
     _raise_with_context("upsert_profile", pubkey, body, r)
 
 
-async def upsert_score(pubkey: str, observer: str, score: int) -> None:
-    """Set the score for `observer` on the doc identified by `pubkey`.
+async def upsert_score(
+    pubkey: str, observer: str, score: int, followers: int = 0
+) -> None:
+    """Set the observer's score + verified-follower count on the doc.
 
-    `add` upserts the cell — inserts a new one or replaces the existing one
-    for that observer.
+    `score` is the rank (influence*100, 0..100) → `quality_scores` tensor;
+    `followers` is the verified-follower count (scorecard.trusted_followers) →
+    `follower_counts` tensor. Both `add` ops upsert the observer's cell (insert
+    or replace). Written in one partial update so the two stay consistent.
     """
     body = {
         "fields": {
@@ -172,7 +193,14 @@ async def upsert_score(pubkey: str, observer: str, score: int) -> None:
                         {"address": {"user": observer}, "value": int(score)}
                     ]
                 }
-            }
+            },
+            "follower_counts": {
+                "add": {
+                    "cells": [
+                        {"address": {"user": observer}, "value": float(followers)}
+                    ]
+                }
+            },
         }
     }
     r = await _get_client().put(
@@ -182,12 +210,15 @@ async def upsert_score(pubkey: str, observer: str, score: int) -> None:
 
 
 async def remove_score(pubkey: str, observer: str) -> None:
-    """Remove the observer's score from the doc's tensor."""
+    """Remove the observer's score + follower count from the doc's tensors."""
     body = {
         "fields": {
             "quality_scores": {
                 "remove": {"addresses": [{"user": observer}]}
-            }
+            },
+            "follower_counts": {
+                "remove": {"addresses": [{"user": observer}]}
+            },
         }
     }
     r = await _get_client().put(_doc_url(pubkey), json=body)
@@ -198,31 +229,31 @@ async def remove_score(pubkey: str, observer: str) -> None:
 
 
 async def batch_upsert_scores(
-    upserts: list[tuple[str, int]],
+    upserts: list[tuple[str, int, int]],
     removes: list[str],
     observer: str,
 ) -> tuple[int, int]:
     """Run many score upserts + removes concurrently against Vespa.
 
-    `upserts` is a list of (pubkey, score) tuples; `removes` is a list of
-    pubkeys whose score for `observer` should be deleted. Returns (n_success,
-    n_failed). Individual failures are logged but never raised — the caller
-    treats scores as best-effort search mirror, not source of truth.
+    `upserts` is a list of (pubkey, score, followers) tuples; `removes` is a
+    list of pubkeys whose score for `observer` should be deleted. Returns
+    (n_success, n_failed). Individual failures are logged but never raised — the
+    caller treats scores as best-effort search mirror, not source of truth.
     """
     if not upserts and not removes:
         return 0, 0
 
     sem = asyncio.Semaphore(_BATCH_CONCURRENCY)
 
-    async def _do_upsert(pubkey: str, score: int) -> None:
+    async def _do_upsert(pubkey: str, score: int, followers: int) -> None:
         async with sem:
-            await upsert_score(pubkey, observer, score)
+            await upsert_score(pubkey, observer, score, followers)
 
     async def _do_remove(pubkey: str) -> None:
         async with sem:
             await remove_score(pubkey, observer)
 
-    tasks: list = [_do_upsert(pk, sc) for pk, sc in upserts]
+    tasks: list = [_do_upsert(pk, sc, fc) for pk, sc, fc in upserts]
     tasks += [_do_remove(pk) for pk in removes]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -298,10 +329,16 @@ def _field_clauses(field: str, var: str, max_edits: int) -> list[str]:
 
 
 def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
-    """All match clauses for one query word across name/display_name/about + grams."""
+    """All match clauses for one query word across the searchable fields + grams.
+
+    name/display_name/about are the primary text signal (and feed the rank
+    profile's text functions). username/nip05 also feed the match-quality tier
+    (has_token_match in doc.sd). lud16/website are recall-only (P1). See
+    docs/search-vs-tapestry.md §8.4.
+    """
     me = _word_max_edits(literal)
     clauses: list[str] = []
-    for field in ("name", "display_name", "about"):
+    for field in ("name", "display_name", "about", "username", "nip05", "lud16", "website"):
         clauses += _field_clauses(field, var, me)
     if with_grams:
         for gram_field in ("name_gram", "display_name_gram"):
@@ -401,5 +438,8 @@ async def search(
         mf = fields.pop("matchfeatures", None) or {}
         fields["_relevance"] = h.get("relevance")
         fields["_quality_score"] = mf.get("user_score")
+        # verified_followers is only in match-features for the sort_followers
+        # profile; other profiles leave it None.
+        fields["_followers"] = mf.get("verified_followers")
         out.append(fields)
     return out

--- a/app/core/vespa_query.py
+++ b/app/core/vespa_query.py
@@ -1,0 +1,147 @@
+"""Pure, dependency-free YQL query builders for the Vespa profile search.
+
+Extracted from `vespa.py` so the EXACT same query the live search sends can be
+reused by diagnostic tooling (`scripts/analyze_pubkey.py`) without importing
+settings/httpx. Stdlib-only — no third-party imports — so a standalone script can
+build the query and run it against a port-forwarded Vespa.
+
+See docs/search-vs-tapestry.md §8.4 / §10 / §11.
+"""
+
+# How many query words we label / parametrize at most.
+MAX_QUERY_WORDS = 6
+
+# Field roles for match labeling (consumed by match_quality / affiliation_match
+# in doc.sd). NB itemRawScore does NOT populate for plain text terms, so the
+# labels are currently inert (§11.1) — kept for a future verbatim-field revival.
+# The real name-tier gate is matchCount() in doc.sd's has_token_match(), which
+# must list the same primary fields.
+#   primary     — name/display_name/username/nip05/lud16 (nip05 & lud16 are both
+#                 @-address identity fields, so lud16 is treated like nip05)
+#   affiliation — bio + website (only the EXACT clause labeled)
+_PRIMARY_FIELDS = ("name", "display_name", "username", "nip05", "lud16")
+_AFFILIATION_FIELDS = ("about", "website")
+_SEARCH_FIELDS = ("name", "display_name", "about", "username", "nip05", "lud16", "website")
+
+
+def _field_role(field: str) -> str:
+    if field in _PRIMARY_FIELDS:
+        return "primary"
+    if field in _AFFILIATION_FIELDS:
+        return "affiliation"
+    return "recall"
+
+
+def _gram_clause(text: str, gram_field: str, gram_size: int = 3) -> str:
+    """OR of every trigram in `text` against `gram_field`."""
+    grams = set()
+    for word in text.lower().split():
+        for i in range(max(1, len(word) - gram_size + 1)):
+            g = word[i : i + gram_size]
+            if len(g) == gram_size and g.isalnum():
+                grams.add(g)
+    if not grams:
+        return ""
+    return (
+        "(" + " or ".join(f'{gram_field} contains "{g}"' for g in sorted(grams)) + ")"
+    )
+
+
+def _about_gram_clause_for_word(word: str, gram_size: int = 3) -> str:
+    """AND of one word's trigrams against `about_gram` (discriminative)."""
+    grams = [
+        word[i : i + gram_size]
+        for i in range(len(word) - gram_size + 1)
+        if word[i : i + gram_size].isalnum()
+        and len(word[i : i + gram_size]) == gram_size
+    ]
+    if not grams:
+        return ""
+    return "(" + " and ".join(f'about_gram contains "{g}"' for g in grams) + ")"
+
+
+def _word_max_edits(word: str) -> int:
+    """Per-word fuzzy budget, length-gated like Meilisearch: <4 → exact/prefix
+    only, ≥4 → 1 edit, ≥9 → 2 edits. See docs §10."""
+    if len(word) >= 9:
+        return 2
+    if len(word) >= 4:
+        return 1
+    return 0
+
+
+def _field_clauses(field: str, var: str, max_edits: int, role: str) -> list[str]:
+    """Match clauses for one (field, word): exact, prefix, and up to two fuzzy
+    tiers. Labels depend on the field `role` (§10 / §11)."""
+    def _ann(extra: list[str], label: str | None) -> str:
+        ann = [f'defaultIndex:"{field}"'] + extra
+        if label:
+            ann.append(f'label:"{label}"')
+        return "{" + ",".join(ann) + "}"
+
+    ex_label = {"primary": "mtch_exact", "affiliation": "mtch_affil"}.get(role)
+    pf_label = "mtch_prefix" if role == "primary" else None
+    clauses = [
+        f"({_ann([], ex_label)}userInput({var}))",
+        f"({_ann(['prefix:true'], pf_label)}userInput({var}))",
+    ]
+    # prefixLength:2 — the first two characters must match exactly.
+    if max_edits >= 1:
+        fz1 = "mtch_fz1" if role == "primary" else None
+        clauses.append(
+            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], fz1)}userInput({var}))"
+        )
+    if max_edits >= 2:
+        fz2 = "mtch_fz2" if role == "primary" else None
+        clauses.append(
+            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], fz2)}userInput({var}))"
+        )
+    return clauses
+
+
+def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
+    """All match clauses for one query word across the searchable fields + grams."""
+    me = _word_max_edits(literal)
+    clauses: list[str] = []
+    for field in _SEARCH_FIELDS:
+        clauses += _field_clauses(field, var, me, _field_role(field))
+    if with_grams:
+        for gram_field in ("name_gram", "display_name_gram"):
+            gc = _gram_clause(literal, gram_field)
+            if gc:
+                clauses.append(gc)
+        agc = _about_gram_clause_for_word(literal)
+        if agc:
+            clauses.append(agc)
+    return "(" + " or ".join(clauses) + ")"
+
+
+def _build_yql(words: list[str], joined, pairs: list[str]) -> str:
+    """Per-word groups OR'd together, plus a joined-CamelCase variant and
+    adjacent-pair concatenations for >2-word queries."""
+    parts = [_word_group(f"@w{i}", w) for i, w in enumerate(words[:MAX_QUERY_WORDS])]
+    if joined:
+        parts.append(_word_group("@wj", joined, with_grams=False))
+    for i, _ in enumerate(pairs):
+        parts.append(_word_group(f"@wp{i}", pairs[i], with_grams=False))
+    return f"select * from doc where {' or '.join(parts)}"
+
+
+def build_query(query_text: str):
+    """Return (words, yql, word_params) — the EXACT YQL + per-word params the
+    live search sends (minus ranking features). Reused by search() and by
+    diagnostic tooling so they never drift."""
+    words = query_text.split()[:MAX_QUERY_WORDS]
+    joined = "".join(words) if len(words) >= 2 else None
+    pairs = (
+        ["".join(words[i : i + 2]) for i in range(len(words) - 1)]
+        if len(words) >= 3
+        else []
+    )
+    yql = _build_yql(words, joined, pairs)
+    params = {f"w{i}": w for i, w in enumerate(words)}
+    if joined:
+        params["wj"] = joined
+    for i, p in enumerate(pairs):
+        params[f"wp{i}"] = p
+    return words, yql, params

--- a/app/core/vespa_query.py
+++ b/app/core/vespa_query.py
@@ -16,12 +16,14 @@ MAX_QUERY_WORDS = 6
 # labels are currently inert (§11.1) — kept for a future verbatim-field revival.
 # The real name-tier gate is matchCount() in doc.sd's has_token_match(), which
 # must list the same primary fields.
-#   primary     — name/display_name/username/nip05/lud16 (nip05 & lud16 are both
+#   primary     — name/display_name/nip05/lud16 (nip05 & lud16 are both
 #                 @-address identity fields, so lud16 is treated like nip05)
 #   affiliation — bio + website (only the EXACT clause labeled)
-_PRIMARY_FIELDS = ("name", "display_name", "username", "nip05", "lud16")
+# (The deprecated `username` folds into `name` at ingest per NIP-24, so it is no
+# longer a stored/searchable field — see process_strfry_event._FIELD_RESOLUTION.)
+_PRIMARY_FIELDS = ("name", "display_name", "nip05", "lud16")
 _AFFILIATION_FIELDS = ("about", "website")
-_SEARCH_FIELDS = ("name", "display_name", "about", "username", "nip05", "lud16", "website")
+_SEARCH_FIELDS = ("name", "display_name", "about", "nip05", "lud16", "website")
 
 
 def _field_role(field: str) -> str:

--- a/app/message_queue_tasks/process_strfry_event.py
+++ b/app/message_queue_tasks/process_strfry_event.py
@@ -39,16 +39,52 @@ async def process_strfry_event(session: AsyncNeoDriver, event: dict):
         return await process_event_kind_1984(session, event)
 
 
+# Some clients mirror profile fields as kind-0 *tags* in addition to (or
+# instead of) the JSON `content`, and use camelCase variants. We merge both and
+# normalize aliases so neither scheme is missed. See docs/search-vs-tapestry.md §8.4.1.
+_KIND0_TAG_ALIASES = {"displayName": "display_name"}
+
+
+def _extract_kind0_profile(event: dict) -> dict:
+    """Merge a kind-0 event's `content` JSON and profile `tags` into one dict.
+
+    `content` is the base; profile `tags` fill in any keys content didn't
+    provide (content wins on conflict). camelCase aliases (e.g. ``displayName``)
+    are normalized, and only recognized ``PROFILE_FIELDS`` are kept.
+    """
+    merged: dict = {}
+
+    content_raw = event.get("content") or ""
+    if content_raw:
+        try:
+            parsed = json.loads(content_raw)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            merged.update(parsed)
+
+    for tag in event.get("tags") or []:
+        if isinstance(tag, list) and len(tag) >= 2 and isinstance(tag[0], str):
+            key, value = tag[0], tag[1]
+            # Tags only FILL gaps — content (above) wins on conflict.
+            if key not in merged and isinstance(value, str):
+                merged[key] = value
+
+    for alias, canonical in _KIND0_TAG_ALIASES.items():
+        if merged.get(alias) and not merged.get(canonical):
+            merged[canonical] = merged[alias]
+
+    return {k: v for k, v in merged.items() if k in KIND_0_PROFILE_FIELDS}
+
+
 async def process_event_kind_0(event: dict):
     publisher = event["pubkey"]
-    content_raw = event.get("content") or ""
+    profile = _extract_kind0_profile(event)
 
-    try:
-        profile = json.loads(content_raw) if content_raw else {}
-    except json.JSONDecodeError:
-        return
-
-    if not isinstance(profile, dict):
+    # Skip a kind-0 carrying NO recognized profile fields (empty/malformed): the
+    # upsert clears missing fields to "", so an empty event would wipe an
+    # existing good profile. See docs/search-vs-tapestry.md §8.4.1.
+    if not profile:
         return
 
     # Vespa partial update: every standard kind-0 field gets assigned (or

--- a/app/message_queue_tasks/process_strfry_event.py
+++ b/app/message_queue_tasks/process_strfry_event.py
@@ -39,18 +39,45 @@ async def process_strfry_event(session: AsyncNeoDriver, event: dict):
         return await process_event_kind_1984(session, event)
 
 
-# Some clients mirror profile fields as kind-0 *tags* in addition to (or
-# instead of) the JSON `content`, and use camelCase variants. We merge both and
-# normalize aliases so neither scheme is missed. See docs/search-vs-tapestry.md §8.4.1.
-_KIND0_TAG_ALIASES = {"displayName": "display_name"}
+# Canonical kind-0 field -> candidate keys in PRIORITY order (canonical first,
+# deprecated aliases after). We store ONLY the canonical field, picking the first
+# candidate that carries a non-empty value — so a deprecated key merely backfills
+# when the canonical is missing/blank. Per NIP-24, `username` is a deprecated
+# alias of `name` and `displayName` of `display_name`; some clients also send
+# these as kind-0 *tags* rather than in `content`. See docs/search-vs-tapestry.md
+# §8.4.1. Keys must be the canonical PROFILE_FIELDS (KIND_0_PROFILE_FIELDS).
+_FIELD_RESOLUTION: dict[str, tuple[str, ...]] = {
+    "name": ("name", "username"),            # NIP-24: username deprecated -> name
+    "display_name": ("display_name", "displayName"),
+    "about": ("about",),
+    "picture": ("picture",),
+    "banner": ("banner",),
+    "nip05": ("nip05",),
+    "lud06": ("lud06",),
+    "lud16": ("lud16",),
+    "website": ("website",),
+}
+
+# Guard against drift between the resolution table and the Vespa schema fields.
+assert set(_FIELD_RESOLUTION) == set(KIND_0_PROFILE_FIELDS), (
+    "FIELD_RESOLUTION keys must match vespa.PROFILE_FIELDS"
+)
 
 
 def _extract_kind0_profile(event: dict) -> dict:
-    """Merge a kind-0 event's `content` JSON and profile `tags` into one dict.
+    """Resolve each canonical profile field from a kind-0 event's `content` JSON
+    and profile `tags`.
 
-    `content` is the base; profile `tags` fill in any keys content didn't
-    provide (content wins on conflict). camelCase aliases (e.g. ``displayName``)
-    are normalized, and only recognized ``PROFILE_FIELDS`` are kept.
+    Two-level precedence:
+      * source — `content` is the base; profile `tags` only fill keys content
+        didn't provide (content wins on conflict).
+      * candidate — for each canonical field, the first key in
+        ``_FIELD_RESOLUTION`` that carries a non-empty value wins, so a
+        deprecated alias (`username`, `displayName`) only backfills when the
+        canonical key is absent/blank.
+
+    Only canonical ``PROFILE_FIELDS`` are returned; deprecated keys are never
+    surfaced as their own field.
     """
     merged: dict = {}
 
@@ -70,11 +97,14 @@ def _extract_kind0_profile(event: dict) -> dict:
             if key not in merged and isinstance(value, str):
                 merged[key] = value
 
-    for alias, canonical in _KIND0_TAG_ALIASES.items():
-        if merged.get(alias) and not merged.get(canonical):
-            merged[canonical] = merged[alias]
-
-    return {k: v for k, v in merged.items() if k in KIND_0_PROFILE_FIELDS}
+    out: dict = {}
+    for field, candidates in _FIELD_RESOLUTION.items():
+        for key in candidates:
+            value = merged.get(key)
+            if isinstance(value, str) and value.strip():
+                out[field] = value
+                break
+    return out
 
 
 async def process_event_kind_0(event: dict):

--- a/app/message_queue_tasks/upload_nostr_events.py
+++ b/app/message_queue_tasks/upload_nostr_events.py
@@ -273,17 +273,29 @@ async def upsert_scores_to_vespa(
     assert grape_rank_result.scorecards is not None
     changed_pubkeys = set(grape_rank_result.changedScorePubkeys)
 
-    upserts: list[tuple[str, int]] = []
+    # Vespa ingest threshold is DECOUPLED from the Nostr TA publish cutoff
+    # (`cutoff_of_valid_graperank_scores`): we index every profile whose rank is
+    # > 0 so it's searchable, and the rank>=2 *default filter* (set per query)
+    # decides visibility at search time. A scorecard whose rank rounds to 0 is
+    # removed from Vespa here (its cell is stale), NOT kept. The cutoff-based
+    # `pubkeys_to_delete` (gone / dropped-from-scorecards) is honored too.
+    # See docs/search-vs-tapestry.md §8.3.
+    upserts: list[tuple[str, int, int]] = []
+    vespa_removes: set[str] = set(pubkeys_to_delete)
     for pubkey, scorecard in grape_rank_result.scorecards.items():
-        if not VESPA_FULL_SYNC and pubkey not in changed_pubkeys:
-            continue
-        if round(scorecard.influence, 2) < settings.cutoff_of_valid_graperank_scores:
-            continue
-        upserts.append((pubkey, round(scorecard.influence * 100)))
+        rank = round(scorecard.influence * 100)
+        if rank > 0:
+            # Alive in Vespa — never remove it, even if FULL_SYNC is off and we
+            # skip re-pushing it below.
+            vespa_removes.discard(pubkey)
+            if VESPA_FULL_SYNC or pubkey in changed_pubkeys:
+                upserts.append((pubkey, rank, round(scorecard.trusted_followers)))
+        else:
+            vespa_removes.add(pubkey)  # rank rounds to 0 → drop from the index
 
     n_ok, n_failed = await batch_upsert_scores(
         upserts=upserts,
-        removes=list(pubkeys_to_delete),
+        removes=list(vespa_removes),
         observer=observer,
     )
     logger.info(

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -743,3 +743,68 @@ async def get_user_graph_data(
         reported_by=[UserConnection(**x) for x in record["reported_by"]],
         reporting=[UserConnection(**x) for x in record["reporting"]],
     )
+
+
+# ============================================================================
+# Open Ranking (ORE) helpers
+# ============================================================================
+
+
+async def batch_influence_for_pubkeys(
+    session: AsyncNeoDriver,
+    pubkeys: list[str],
+    observer_pubkey: str,
+) -> dict[str, float | None]:
+    """Return {pubkey -> influence_<observer_pubkey>} for every pubkey in
+    `pubkeys`. Unknown pubkeys and pubkeys with no influence property for the
+    given observer are mapped to None. Used by ORE-03 (POST /rank/pubkeys).
+    """
+    if not pubkeys:
+        return {}
+
+    influence_key = f"influence_{observer_pubkey}"
+    query = """
+    UNWIND $pubkeys AS pk
+    OPTIONAL MATCH (user:NostrUser {pubkey: pk})
+    RETURN pk AS pubkey, user[$influence_key] AS influence
+    """
+    result = await session.run(
+        query, pubkeys=pubkeys, influence_key=influence_key
+    )
+    out: dict[str, float | None] = {pk: None for pk in pubkeys}
+    async for record in result:
+        out[record["pubkey"]] = record["influence"]
+    return out
+
+
+async def get_top_inbound_by_influence(
+    session: AsyncNeoDriver,
+    pubkey: str,
+    observer_pubkey: str,
+    relation: str,
+    limit: int,
+) -> list[UserConnection]:
+    """Top `limit` users with an incoming `relation` edge into `pubkey`,
+    sorted by `influence_<observer_pubkey>` DESC, pubkey ASC. Users with no
+    influence property for the observer get sort value -1 (last).
+
+    Used by ORE-06 (relation=FOLLOWS) and ORE-07 (relation=MUTES).
+    """
+    if relation not in ("FOLLOWS", "MUTES", "REPORTS"):
+        raise ValueError(f"Unsupported relation: {relation}")
+
+    influence_key = f"influence_{observer_pubkey}"
+    query = f"""
+    MATCH (other:NostrUser)-[:{relation}]->(user:NostrUser {{pubkey: $pubkey}})
+    WITH other, coalesce(other[$influence_key], -1.0) AS sort_inf
+    RETURN other.pubkey AS pubkey, other[$influence_key] AS influence
+    ORDER BY sort_inf DESC, other.pubkey ASC
+    LIMIT $limit
+    """
+    result = await session.run(
+        query, pubkey=pubkey, influence_key=influence_key, limit=int(limit)
+    )
+    return [
+        UserConnection(pubkey=record["pubkey"], influence=record["influence"])
+        async for record in result
+    ]

--- a/app/routers/nip50/router.py
+++ b/app/routers/nip50/router.py
@@ -28,8 +28,16 @@ from fastapi import APIRouter, Header, Request, Response, WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from app.core.config import settings
+from app.core.database import db_session
 from app.core.loggr import loggr
+from app.core.redis_db import get_redis_client
+from app.core.vespa import (
+    RANK_PROFILE_FILTERED,
+    RANK_PROFILE_SORT_ASC,
+    RANK_PROFILE_SORT_DESC,
+)
 from app.core.vespa import search as vespa_search
+from app.services.brainstorm_pubkey_service import get_or_create_brainstorm_pubkey
 from app.utils.observer import default_observer_pubkey
 
 logger = loggr.get_logger(__name__)
@@ -46,9 +54,45 @@ DEFAULT_HITS = 100
 
 HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
 
-# Tokens the client can embed in the search string. Inspired by tapestry's
-# NIP-50 extensions but kept minimal — only ``observer:<hex>`` for now.
+# Tokens the client can embed in the search string. Mirrors tapestry's
+# NIP-50 extensions, restricted to what brainstorm's Vespa schema can back
+# today (one per-observer metric: ``rank`` == quality_score, 0..100).
 _OBSERVER_TOKEN_RE = re.compile(r"(?:^|\s)observer:([0-9a-fA-F]{64})(?=\s|$)")
+_SORT_TOKEN_RE = re.compile(
+    r"(?:^|\s)sort:([a-zA-Z_]+):(asc|desc)(?=\s|$)", re.IGNORECASE
+)
+_FILTER_TOKEN_RE = re.compile(
+    r"(?:^|\s)filter:([a-zA-Z_]+):(gte|lte|gt|lt|eq):(-?\d+(?:\.\d+)?)(?=\s|$)",
+    re.IGNORECASE,
+)
+
+# Per-observer metrics we can sort / filter on. Map of NIP-50 metric name →
+# the field in the dict returned by vespa.search(). Adding more metrics later
+# (when the Vespa schema grows additional sparse tensors) is a matter of
+# extending this mapping, the rank profiles in doc.sd, and the NIP-11
+# advertisement below.
+_METRIC_FIELDS: dict[str, str] = {
+    "rank": "_quality_score",
+}
+
+# Filter operators we can push into Vespa. The rank_* profiles gate on
+# query(min_rank) via Vespa's rank-score-drop-limit, which is a lower-bound
+# (>=) mechanism — so only gte/gt map natively. lte/lt/eq would need the score
+# stored as a range-queryable attribute (a schema re-model + re-feed); they are
+# intentionally unsupported and the relay NOTICEs the client. See
+# docs/search-precision-and-filtering.md (Problem 2).
+_FILTER_OPS: tuple[str, ...] = ("gte", "gt")
+
+# gt:N is pushed down as min_rank = N + epsilon (a >= gate that excludes N).
+# rank is an integer 0..100, so any epsilon in (0, 1) is exact.
+_GT_EPSILON = 1e-6
+
+# Cold-start dedup: once we've provisioned graperank for an observer we don't
+# want to re-fire it on every search. The Redis NX key auto-expires so a
+# stale observer (e.g. one whose scores never landed because graperank
+# errored) eventually gets re-attempted.
+PROVISION_DEDUP_KEY_FMT = "nip50:provisioned:{pubkey}"
+PROVISION_DEDUP_TTL_SECONDS = 3600
 
 
 # ---------------------------------------------------------------------------
@@ -75,10 +119,40 @@ def _nip11_document() -> dict[str, Any]:
             "extensions": {
                 "observer": {
                     "description": (
-                        "Hex pubkey for WoT point of view. Falls back to the "
-                        "instance's default observer when omitted."
+                        "Hex pubkey for WoT point of view. The first time a "
+                        "new observer is used the relay enqueues a GrapeRank "
+                        "computation in the background; meanwhile the search "
+                        "falls back to the instance's default observer."
                     ),
                     "format": "observer:<hex-pubkey>",
+                },
+                "sort": {
+                    "description": (
+                        "Sort hits by a WoT metric. When omitted, the relay's "
+                        "default rank profile (text relevance \u00d7 quality "
+                        "boost from the observer's perspective) is used."
+                    ),
+                    "format": "sort:<metric>:<asc|desc>",
+                    "metrics": sorted(_METRIC_FIELDS.keys()),
+                },
+                "filter": {
+                    "description": (
+                        "Drop hits whose metric value fails the given "
+                        "comparison. Only lower-bound operators are supported "
+                        "(the relay pushes them into Vespa as a minimum-rank "
+                        "cut-off); other operators are ignored with a NOTICE. "
+                        "Multiple filter tokens are AND-ed (the most "
+                        "restrictive lower bound wins)."
+                    ),
+                    "format": "filter:<metric>:<op>:<value>",
+                    "metrics": sorted(_METRIC_FIELDS.keys()),
+                    "operators": sorted(_FILTER_OPS),
+                    "scales": {
+                        "rank": (
+                            "0-100 integer; the observer's GrapeRank "
+                            "influence score (round(influence * 100))."
+                        ),
+                    },
                 },
             },
         },
@@ -118,18 +192,120 @@ async def relay_info(
 # ---------------------------------------------------------------------------
 # Search string parsing
 # ---------------------------------------------------------------------------
-def _parse_search(raw: str) -> tuple[str, str | None]:
-    """Pull ``observer:<hex>`` out of the search string, return clean query.
+def _parse_search(
+    raw: str,
+) -> tuple[
+    str,
+    str | None,
+    tuple[str, str] | None,
+    list[tuple[str, str, float]],
+    list[str],
+]:
+    """Strip NIP-50 extensions out of the search string.
 
-    Unknown ``key:value`` tokens are left untouched so Vespa can still match
-    them as plain text (NIP-50 says relays MAY ignore unknown extensions).
+    Returns ``(clean_query, observer, sort_spec, filters, notices)`` where
+    ``sort_spec`` is ``(metric, direction)`` or ``None``, ``filters`` is a
+    list of ``(metric, op, value)`` triples (AND-ed at apply time), and
+    ``notices`` collects human-readable strings describing tokens we parsed
+    but had to drop (unknown metric, unsupported op, etc.) so the caller can
+    relay them to the client via NIP-01 ``NOTICE`` frames.
+
+    Unknown ``key:value`` tokens that don't match any of our extension
+    regexes are left in the query — NIP-50 allows relays to treat unknown
+    extensions as plain text (and Vespa's text matcher will simply ignore
+    them if they don't match any indexed term).
     """
     observer: str | None = None
+    sort_spec: tuple[str, str] | None = None
+    filters: list[tuple[str, str, float]] = []
+    notices: list[str] = []
+
+    def _strip(text: str, start: int, end: int) -> str:
+        return (text[:start] + " " + text[end:]).strip()
+
     m = _OBSERVER_TOKEN_RE.search(raw)
     if m:
         observer = m.group(1).lower()
-        raw = (raw[: m.start()] + " " + raw[m.end() :]).strip()
-    return raw.strip(), observer
+        raw = _strip(raw, m.start(), m.end())
+
+    # Only the LAST sort token wins if multiple are supplied; same as how
+    # most query languages handle conflicting order-by clauses.
+    for m in list(_SORT_TOKEN_RE.finditer(raw)):
+        metric = m.group(1).lower()
+        direction = m.group(2).lower()
+        if metric not in _METRIC_FIELDS:
+            notices.append(
+                f"sort metric {metric!r} not supported; ignoring (supported: "
+                f"{', '.join(sorted(_METRIC_FIELDS))})"
+            )
+        else:
+            sort_spec = (metric, direction)
+    raw = _SORT_TOKEN_RE.sub(" ", raw).strip()
+
+    for m in list(_FILTER_TOKEN_RE.finditer(raw)):
+        metric = m.group(1).lower()
+        op = m.group(2).lower()
+        try:
+            value = float(m.group(3))
+        except ValueError:
+            notices.append(f"filter value {m.group(3)!r} not numeric; ignoring")
+            continue
+        if metric not in _METRIC_FIELDS:
+            notices.append(
+                f"filter metric {metric!r} not supported; ignoring "
+                f"(supported: {', '.join(sorted(_METRIC_FIELDS))})"
+            )
+            continue
+        if op not in _FILTER_OPS:
+            notices.append(
+                f"filter op {op!r} not supported; ignoring "
+                f"(supported: {', '.join(sorted(_FILTER_OPS))})"
+            )
+            continue
+        filters.append((metric, op, value))
+    raw = _FILTER_TOKEN_RE.sub(" ", raw).strip()
+
+    return raw, observer, sort_spec, filters, notices
+
+
+def _select_ranking(
+    sort_spec: tuple[str, str] | None,
+    filters: list[tuple[str, str, float]],
+) -> tuple[str | None, float | None]:
+    """Map parsed sort/filter tokens to a Vespa rank profile + min_rank.
+
+    Returns ``(ranking_profile, min_rank)`` to hand to ``vespa.search``:
+
+      * ``ranking_profile`` is ``None`` (use the default profile) when there's
+        neither a sort nor a filter; otherwise one of the ``RANK_PROFILE_*``
+        names. The sort direction picks asc/desc; a filter with no sort uses the
+        filtered profile (default relevance order, low-trust hits dropped).
+      * ``min_rank`` is the most restrictive lower bound across all filter
+        tokens (``gte`` → value, ``gt`` → value + epsilon), or ``None`` when
+        there's no filter. Vespa drops hits scoring below it.
+
+    All sort/filter happens inside Vespa now — there is no Python post-pass.
+    Only the per-observer ``rank`` metric exists today, so every token's metric
+    is ``rank``; the structure leaves room for more metrics later.
+    """
+    min_rank: float | None = None
+    for _metric, op, value in filters:
+        threshold = value if op == "gte" else value + _GT_EPSILON
+        min_rank = threshold if min_rank is None else max(min_rank, threshold)
+
+    if sort_spec is not None:
+        _metric, direction = sort_spec
+        profile = (
+            RANK_PROFILE_SORT_ASC
+            if direction == "asc"
+            else RANK_PROFILE_SORT_DESC
+        )
+    elif min_rank is not None:
+        profile = RANK_PROFILE_FILTERED
+    else:
+        profile = None
+
+    return profile, min_rank
 
 
 # ---------------------------------------------------------------------------
@@ -242,9 +418,14 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
         return
 
     raw_search: str = search_filter["search"]
-    query, observer_override = _parse_search(raw_search)
+    query, observer_override, sort_spec, filters, parse_notices = _parse_search(
+        raw_search
+    )
+    for note in parse_notices:
+        await _send_json(ws, ["NOTICE", note])
+
     if not query:
-        # Pure ``observer:<hex>`` with no actual query text — nothing to search.
+        # Pure extension tokens with no actual query text — nothing to search.
         await _send_json(ws, ["EOSE", sub_id])
         return
 
@@ -254,14 +435,32 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
     else:
         hits = DEFAULT_HITS
 
+    # Sort + filter are pushed into Vespa via a dedicated rank profile and a
+    # query(min_rank) cut-off, so Vespa's top-N IS the answer — no over-fetch,
+    # no Python re-ranking. See docs/search-precision-and-filtering.md.
+    ranking_profile, min_rank = _select_ranking(sort_spec, filters)
+
+    # Ascending sort by trust wants the lowest-scoring docs first; the default
+    # "drop zero-score hits" would hide exactly those, so allow them here only.
+    ascending_sort = sort_spec is not None and sort_spec[1] == "asc"
+
     observer = observer_override or default_observer_pubkey()
+
+    # Fire cold-start provisioning before running the search — it's a
+    # fire-and-forget background coroutine so it never delays the response.
+    # Only triggered for explicit observers (the default observer is always
+    # provisioned by the periodic graperank cronjob).
+    if observer_override:
+        asyncio.create_task(_maybe_provision_observer(observer_override))
 
     try:
         results = await vespa_search(
             query_text=query,
             user_pubkey=observer,
             hits=hits,
-            include_zero_score_results=False,
+            include_zero_score_results=ascending_sort,
+            ranking_profile=ranking_profile,
+            min_rank=min_rank,
         )
     except Exception as exc:
         logger.exception("nip50: vespa search failed: %r", exc)
@@ -269,7 +468,7 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
         await _send_json(ws, ["EOSE", sub_id])
         return
 
-    # Preserve Vespa's rank order when emitting events.
+    # Results already arrive in Vespa rank order, filtered + sorted as asked.
     ranked_pubkeys: list[str] = []
     seen: set[str] = set()
     for hit in results:
@@ -290,13 +489,74 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
 
     await _send_json(ws, ["EOSE", sub_id])
     logger.info(
-        "nip50: sub=%s query=%r observer=%s hits=%d emitted=%d",
+        "nip50: sub=%s query=%r observer=%s profile=%s min_rank=%s "
+        "returned=%d emitted=%d",
         sub_id,
         query,
         observer[:12],
-        len(ranked_pubkeys),
+        ranking_profile or "default",
+        min_rank,
+        len(results),
         emitted,
     )
+
+
+# ---------------------------------------------------------------------------
+# Cold-start: trigger graperank for a fresh observer on first use
+# ---------------------------------------------------------------------------
+async def _maybe_provision_observer(observer: str) -> None:
+    """Fire-and-forget GrapeRank provisioning for a new observer.
+
+    First search for an observer the relay hasn't seen before triggers a
+    GrapeRank job for that observer; the search itself returns whatever
+    Vespa has now (typically a mix of the default observer's scores plus
+    zero-score hits) and subsequent searches will see the personalized
+    scores once the job completes.
+
+    Dedup is via a Redis NX key so a burst of searches for the same
+    just-arrived observer fires exactly one GrapeRank job. The key expires
+    after an hour so a job that errored gets re-attempted.
+
+    This function never raises — every failure mode is logged-and-swallowed
+    because the search itself has already returned (or is about to). The
+    user-visible behavior is at worst \"first few searches not personalized
+    yet\" rather than a search error.
+    """
+    redis_client = get_redis_client()
+    key = PROVISION_DEDUP_KEY_FMT.format(pubkey=observer)
+    try:
+        # SET key val NX EX ttl — returns truthy only the first time.
+        first = await redis_client.set(
+            key, "1", nx=True, ex=PROVISION_DEDUP_TTL_SECONDS
+        )
+    except Exception as exc:
+        # Redis unhealthy — log and skip rather than spamming GrapeRank.
+        logger.warning("nip50: redis dedup check failed for %s: %r", observer[:12], exc)
+        return
+    if not first:
+        return
+    try:
+        async with db_session() as db:
+            result = await get_or_create_brainstorm_pubkey(
+                db, nostr_pubkey=observer
+            )
+            await db.commit()
+        logger.info(
+            "nip50: cold-start provisioning for observer=%s triggered=%s",
+            observer[:12],
+            bool(result.triggered_graperank),
+        )
+    except Exception as exc:
+        # Drop the dedup key so the next search can retry.
+        try:
+            await redis_client.delete(key)
+        except Exception:
+            pass
+        logger.warning(
+            "nip50: cold-start provisioning failed for %s: %r",
+            observer[:12],
+            exc,
+        )
 
 
 @router.websocket("/relay")

--- a/app/routers/nip50/router.py
+++ b/app/routers/nip50/router.py
@@ -1,0 +1,344 @@
+"""NIP-50 search relay endpoint.
+
+Exposes a single resource at ``/relay`` that speaks just enough of the Nostr
+relay protocol to satisfy NIP-50 search clients:
+
+  * ``GET /relay`` with ``Accept: application/nostr+json`` returns a NIP-11
+    relay-information document advertising ``supported_nips = [1, 11, 50]``.
+  * ``WebSocket /relay`` accepts NIP-01 frames. Only ``REQ`` messages whose
+    filter contains a ``search`` field are honoured; everything else gets a
+    quick ``EOSE`` or a polite ``OK false`` so the connection stays well-behaved
+    without us pretending to be a full relay.
+
+Search execution reuses the existing Vespa pipeline (``app.core.vespa.search``)
+and then fetches the *original* signed kind-0 events from the cluster-internal
+strfry instance configured via ``settings.nip50_backing_relay_url``. That way
+the events we hand back have valid ``id`` + ``sig``, so any standards-compliant
+client (Amethyst, etc.) will accept them.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import Any
+
+import websockets
+from fastapi import APIRouter, Header, Request, Response, WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from app.core.config import settings
+from app.core.loggr import loggr
+from app.core.vespa import search as vespa_search
+from app.utils.observer import default_observer_pubkey
+
+logger = loggr.get_logger(__name__)
+
+router = APIRouter()
+
+# Anchor the supported kinds in one place. We only index kind 0 profiles.
+SUPPORTED_KINDS: tuple[int, ...] = (0,)
+
+# Cap how many hits we ever ask Vespa for in one search, regardless of what
+# the client requested. Mirrors RESULTS_LIMIT in the HTTP search router.
+MAX_HITS = 400
+DEFAULT_HITS = 100
+
+HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Tokens the client can embed in the search string. Inspired by tapestry's
+# NIP-50 extensions but kept minimal — only ``observer:<hex>`` for now.
+_OBSERVER_TOKEN_RE = re.compile(r"(?:^|\s)observer:([0-9a-fA-F]{64})(?=\s|$)")
+
+
+# ---------------------------------------------------------------------------
+# NIP-11 relay info
+# ---------------------------------------------------------------------------
+def _nip11_document() -> dict[str, Any]:
+    return {
+        "name": "brainstorm-search",
+        "description": (
+            "NIP-50 search-only relay backed by the Brainstorm Vespa profile "
+            "index. Returns kind-0 profile events ranked by Web-of-Trust "
+            "quality score from the observer's perspective."
+        ),
+        "supported_nips": [1, 11, 50],
+        "software": "brainstorm_server",
+        "version": "0.1.0",
+        "limitation": {
+            "auth_required": False,
+            "payment_required": False,
+            "restricted_writes": True,
+        },
+        "search_capabilities": {
+            "supported_kinds": list(SUPPORTED_KINDS),
+            "extensions": {
+                "observer": {
+                    "description": (
+                        "Hex pubkey for WoT point of view. Falls back to the "
+                        "instance's default observer when omitted."
+                    ),
+                    "format": "observer:<hex-pubkey>",
+                },
+            },
+        },
+    }
+
+
+@router.get(
+    path="/relay",
+    summary="NIP-11 relay information / landing page",
+    include_in_schema=False,
+)
+async def relay_info(
+    request: Request,
+    accept: str | None = Header(default=None),
+) -> Response:
+    """Serve the NIP-11 document when negotiated, else a plain landing page.
+
+    Per NIP-11, a relay advertises its capabilities at the same URL clients
+    connect to over WebSocket, distinguished only by the ``Accept`` header.
+    """
+    if accept and "application/nostr+json" in accept.lower():
+        body = json.dumps(_nip11_document())
+        return Response(
+            content=body,
+            media_type="application/nostr+json",
+            headers={"Access-Control-Allow-Origin": "*"},
+        )
+    return Response(
+        content=(
+            "Brainstorm NIP-50 search relay. Connect via WebSocket to this "
+            "same URL and send a NIP-01 REQ with a 'search' filter."
+        ),
+        media_type="text/plain",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search string parsing
+# ---------------------------------------------------------------------------
+def _parse_search(raw: str) -> tuple[str, str | None]:
+    """Pull ``observer:<hex>`` out of the search string, return clean query.
+
+    Unknown ``key:value`` tokens are left untouched so Vespa can still match
+    them as plain text (NIP-50 says relays MAY ignore unknown extensions).
+    """
+    observer: str | None = None
+    m = _OBSERVER_TOKEN_RE.search(raw)
+    if m:
+        observer = m.group(1).lower()
+        raw = (raw[: m.start()] + " " + raw[m.end() :]).strip()
+    return raw.strip(), observer
+
+
+# ---------------------------------------------------------------------------
+# Strfry round-trip for original signed events
+# ---------------------------------------------------------------------------
+async def _fetch_kind0_events(authors: list[str]) -> dict[str, dict]:
+    """Fetch latest kind-0 events for the given authors from internal strfry.
+
+    Returns a mapping ``pubkey -> event``. Missing authors are simply absent.
+    On timeout or transport error we log and return whatever we have so far —
+    the search result degrades gracefully rather than failing the whole REQ.
+    """
+    if not authors:
+        return {}
+
+    sub_id = f"nip50-{id(authors)}"
+    req = json.dumps(
+        ["REQ", sub_id, {"kinds": [0], "authors": authors, "limit": len(authors)}]
+    )
+    close_msg = json.dumps(["CLOSE", sub_id])
+    events: dict[str, dict] = {}
+
+    url = settings.nip50_backing_relay_url
+    timeout = settings.nip50_strfry_timeout_seconds
+
+    try:
+        async with asyncio.timeout(timeout):
+            async with websockets.connect(url, open_timeout=timeout) as ws:
+                await ws.send(req)
+                while True:
+                    raw = await ws.recv()
+                    try:
+                        msg = json.loads(raw)
+                    except (TypeError, ValueError):
+                        continue
+                    if not isinstance(msg, list) or not msg:
+                        continue
+                    if msg[0] == "EVENT" and len(msg) >= 3 and msg[1] == sub_id:
+                        ev = msg[2]
+                        pk = ev.get("pubkey")
+                        # Keep the newest event per author (strfry usually
+                        # returns newest-first, but be defensive).
+                        prev = events.get(pk)
+                        if prev is None or ev.get("created_at", 0) >= prev.get(
+                            "created_at", 0
+                        ):
+                            events[pk] = ev
+                    elif msg[0] == "EOSE" and len(msg) >= 2 and msg[1] == sub_id:
+                        try:
+                            await ws.send(close_msg)
+                        except Exception:
+                            pass
+                        break
+                    elif msg[0] == "CLOSED" and len(msg) >= 2 and msg[1] == sub_id:
+                        break
+    except (asyncio.TimeoutError, TimeoutError):
+        logger.warning(
+            "nip50: strfry fetch timed out after %.1fs (got %d/%d events)",
+            timeout,
+            len(events),
+            len(authors),
+        )
+    except Exception as exc:
+        logger.warning("nip50: strfry fetch failed: %r", exc)
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# WebSocket message handling
+# ---------------------------------------------------------------------------
+async def _send_json(ws: WebSocket, payload: list) -> None:
+    """Send a NIP-01 frame; swallow disconnects so handlers can keep looping."""
+    try:
+        await ws.send_text(json.dumps(payload))
+    except (WebSocketDisconnect, RuntimeError):
+        # Caller will notice on the next recv() and exit the loop.
+        pass
+
+
+def _filter_supports_kind0(f: dict) -> bool:
+    """A NIP-01 filter matches kind 0 iff ``kinds`` is absent or contains 0."""
+    kinds = f.get("kinds")
+    if kinds is None:
+        return True
+    return isinstance(kinds, list) and 0 in kinds
+
+
+async def _handle_req(ws: WebSocket, msg: list) -> None:
+    if len(msg) < 3 or not isinstance(msg[1], str):
+        return
+    sub_id: str = msg[1]
+    filters = [f for f in msg[2:] if isinstance(f, dict)]
+
+    # Find the first filter that (a) carries a search string and (b) could
+    # plausibly match kind 0. Anything else gets an empty EOSE — we don't
+    # serve general Nostr traffic from this endpoint.
+    search_filter = next(
+        (
+            f
+            for f in filters
+            if isinstance(f.get("search"), str)
+            and f["search"].strip()
+            and _filter_supports_kind0(f)
+        ),
+        None,
+    )
+    if search_filter is None:
+        await _send_json(ws, ["EOSE", sub_id])
+        return
+
+    raw_search: str = search_filter["search"]
+    query, observer_override = _parse_search(raw_search)
+    if not query:
+        # Pure ``observer:<hex>`` with no actual query text — nothing to search.
+        await _send_json(ws, ["EOSE", sub_id])
+        return
+
+    requested_limit = search_filter.get("limit")
+    if isinstance(requested_limit, int) and requested_limit > 0:
+        hits = min(requested_limit, MAX_HITS)
+    else:
+        hits = DEFAULT_HITS
+
+    observer = observer_override or default_observer_pubkey()
+
+    try:
+        results = await vespa_search(
+            query_text=query,
+            user_pubkey=observer,
+            hits=hits,
+            include_zero_score_results=False,
+        )
+    except Exception as exc:
+        logger.exception("nip50: vespa search failed: %r", exc)
+        await _send_json(ws, ["NOTICE", f"search backend error: {exc!s}"])
+        await _send_json(ws, ["EOSE", sub_id])
+        return
+
+    # Preserve Vespa's rank order when emitting events.
+    ranked_pubkeys: list[str] = []
+    seen: set[str] = set()
+    for hit in results:
+        pk = hit.get("pubkey")
+        if isinstance(pk, str) and HEX64_RE.match(pk) and pk not in seen:
+            ranked_pubkeys.append(pk)
+            seen.add(pk)
+
+    events_by_pubkey = await _fetch_kind0_events(ranked_pubkeys)
+
+    emitted = 0
+    for pk in ranked_pubkeys:
+        ev = events_by_pubkey.get(pk)
+        if ev is None:
+            continue
+        await _send_json(ws, ["EVENT", sub_id, ev])
+        emitted += 1
+
+    await _send_json(ws, ["EOSE", sub_id])
+    logger.info(
+        "nip50: sub=%s query=%r observer=%s hits=%d emitted=%d",
+        sub_id,
+        query,
+        observer[:12],
+        len(ranked_pubkeys),
+        emitted,
+    )
+
+
+@router.websocket("/relay")
+async def relay_ws(ws: WebSocket) -> None:
+    """Single WebSocket endpoint that speaks NIP-01 framing for NIP-50 only."""
+    await ws.accept(subprotocol=None)
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                msg = json.loads(raw)
+            except (TypeError, ValueError):
+                await _send_json(ws, ["NOTICE", "invalid json"])
+                continue
+            if not isinstance(msg, list) or not msg:
+                await _send_json(ws, ["NOTICE", "invalid frame"])
+                continue
+
+            verb = msg[0]
+            if verb == "REQ":
+                await _handle_req(ws, msg)
+            elif verb == "CLOSE":
+                # No per-sub state to clean up — searches complete synchronously.
+                continue
+            elif verb == "EVENT":
+                ev = msg[1] if len(msg) >= 2 and isinstance(msg[1], dict) else {}
+                ev_id = ev.get("id", "")
+                await _send_json(
+                    ws,
+                    ["OK", ev_id, False, "blocked: read-only NIP-50 search relay"],
+                )
+            elif verb in ("AUTH", "COUNT"):
+                # We don't implement these; stay silent (per spec, AUTH is
+                # optional; COUNT requires NIP-45 which we don't advertise).
+                continue
+            else:
+                await _send_json(ws, ["NOTICE", f"unsupported verb: {verb}"])
+    except WebSocketDisconnect:
+        return
+    except Exception as exc:
+        logger.warning("nip50: ws handler crashed: %r", exc)
+        try:
+            await ws.close()
+        except Exception:
+            pass

--- a/app/routers/nip50/router.py
+++ b/app/routers/nip50/router.py
@@ -32,9 +32,10 @@ from app.core.database import db_session
 from app.core.loggr import loggr
 from app.core.redis_db import get_redis_client
 from app.core.vespa import (
-    RANK_PROFILE_FILTERED,
+    DEFAULT_MIN_RANK,
     RANK_PROFILE_SORT_ASC,
     RANK_PROFILE_SORT_DESC,
+    RANK_PROFILE_SORT_FOLLOWERS,
 )
 from app.core.vespa import search as vespa_search
 from app.services.brainstorm_pubkey_service import get_or_create_brainstorm_pubkey
@@ -73,7 +74,14 @@ _FILTER_TOKEN_RE = re.compile(
 # advertisement below.
 _METRIC_FIELDS: dict[str, str] = {
     "rank": "_quality_score",
+    "followers": "_followers",
 }
+
+# Sort can use either metric (`followers` is the default order). Filter can
+# currently only use `rank` — Vespa gates on query(min_rank) over the rank
+# tensor; there's no follower-count gate yet. See docs/search-vs-tapestry.md §8.
+_SORT_METRICS: frozenset = frozenset({"rank", "followers"})
+_FILTER_METRICS: frozenset = frozenset({"rank"})
 
 # Filter operators we can push into Vespa. The rank_* profiles gate on
 # query(min_rank) via Vespa's rank-score-drop-limit, which is a lower-bound
@@ -233,10 +241,10 @@ def _parse_search(
     for m in list(_SORT_TOKEN_RE.finditer(raw)):
         metric = m.group(1).lower()
         direction = m.group(2).lower()
-        if metric not in _METRIC_FIELDS:
+        if metric not in _SORT_METRICS:
             notices.append(
                 f"sort metric {metric!r} not supported; ignoring (supported: "
-                f"{', '.join(sorted(_METRIC_FIELDS))})"
+                f"{', '.join(sorted(_SORT_METRICS))})"
             )
         else:
             sort_spec = (metric, direction)
@@ -250,10 +258,10 @@ def _parse_search(
         except ValueError:
             notices.append(f"filter value {m.group(3)!r} not numeric; ignoring")
             continue
-        if metric not in _METRIC_FIELDS:
+        if metric not in _FILTER_METRICS:
             notices.append(
                 f"filter metric {metric!r} not supported; ignoring "
-                f"(supported: {', '.join(sorted(_METRIC_FIELDS))})"
+                f"(supported: {', '.join(sorted(_FILTER_METRICS))})"
             )
             continue
         if op not in _FILTER_OPS:
@@ -276,38 +284,38 @@ def _select_ranking(
 
     Returns ``(ranking_profile, min_rank)`` to hand to ``vespa.search``:
 
-      * ``ranking_profile`` is always one of the ``RANK_PROFILE_*`` names — the
-        NIP-50 relay is TRUST-SORTED-WITHIN-TEXT by default (docs/search-vs-tapestry.md
-        §6), so with no sort token we use ``rank_desc`` rather than the
-        pure-text default profile that ``/search/byText`` uses. The sort
-        direction picks asc/desc; a filter with no sort uses the filtered
-        profile (pure-text order, low-trust hits dropped).
-      * ``min_rank`` is the most restrictive lower bound across all filter
-        tokens (``gte`` → value, ``gt`` → value + epsilon), or ``None`` when
-        there's no filter. Vespa drops hits scoring below it.
+      * ``ranking_profile`` is always one of the ``RANK_PROFILE_*`` names. The
+        NIP-50 default (no sort token) is ``sort_followers`` — text match, sorted
+        by verified-follower count (docs/search-vs-tapestry.md §8.1).
+        ``sort:followers`` keeps that; ``sort:rank:desc/asc`` orders by trust.
+      * ``min_rank`` is the rank>=N filter floor: the most restrictive
+        ``filter:rank`` lower bound if any (``gte`` → value, ``gt`` → value +
+        epsilon), otherwise the product default ``DEFAULT_MIN_RANK`` (rank>=2).
+        Vespa drops hits scoring below it.
 
-    All sort/filter happens inside Vespa now — there is no Python post-pass.
-    Only the per-observer ``rank`` metric exists today, so every token's metric
-    is ``rank``; the structure leaves room for more metrics later.
+    All sort/filter happens inside Vespa — there is no Python post-pass. Sort
+    supports ``rank`` and ``followers``; filter supports ``rank`` only.
     """
     min_rank: float | None = None
     for _metric, op, value in filters:
         threshold = value if op == "gte" else value + _GT_EPSILON
         min_rank = threshold if min_rank is None else max(min_rank, threshold)
+    # No explicit filter → apply the default rank>=2 floor (§8.1). An explicit
+    # filter:rank overrides it (even lower), since that's the caller configuring.
+    if min_rank is None:
+        min_rank = DEFAULT_MIN_RANK
 
     if sort_spec is not None:
-        _metric, direction = sort_spec
-        profile = (
-            RANK_PROFILE_SORT_ASC
-            if direction == "asc"
-            else RANK_PROFILE_SORT_DESC
-        )
-    elif min_rank is not None:
-        profile = RANK_PROFILE_FILTERED
+        metric, direction = sort_spec
+        if metric == "followers":
+            profile = RANK_PROFILE_SORT_FOLLOWERS  # followers is desc-only
+        elif direction == "asc":
+            profile = RANK_PROFILE_SORT_ASC
+        else:
+            profile = RANK_PROFILE_SORT_DESC
     else:
-        # No sort, no filter: the NIP-50 default is trust-sorted-within-text,
-        # so default to rank_desc (NOT the pure-text /search/byText profile).
-        profile = RANK_PROFILE_SORT_DESC
+        # No sort: the popular-first default.
+        profile = RANK_PROFILE_SORT_FOLLOWERS
 
     return profile, min_rank
 
@@ -444,11 +452,9 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
     # no Python re-ranking. See docs/search-precision-and-filtering.md.
     ranking_profile, min_rank = _select_ranking(sort_spec, filters)
 
-    # Trust-sorted-within-text INCLUDES unscored hits — they backfill below the
-    # trusted ones (mirroring tapestry's phase-2 backfill, docs/search-vs-tapestry.md
-    # §6). The only time we drop zero-score hits is when an explicit filter:rank
-    # cut-off is set, which means "only trusted profiles".
-    backfill_unscored = min_rank is None
+    # Vespa already drops hits below query(min_rank) (default rank>=2, §8.1), so
+    # the Python zero-score post-filter is redundant here — leave it off.
+    include_unscored = False
 
     observer = observer_override or default_observer_pubkey()
 
@@ -464,7 +470,7 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
             query_text=query,
             user_pubkey=observer,
             hits=hits,
-            include_zero_score_results=backfill_unscored,
+            include_zero_score_results=include_unscored,
             ranking_profile=ranking_profile,
             min_rank=min_rank,
         )

--- a/app/routers/nip50/router.py
+++ b/app/routers/nip50/router.py
@@ -276,10 +276,12 @@ def _select_ranking(
 
     Returns ``(ranking_profile, min_rank)`` to hand to ``vespa.search``:
 
-      * ``ranking_profile`` is ``None`` (use the default profile) when there's
-        neither a sort nor a filter; otherwise one of the ``RANK_PROFILE_*``
-        names. The sort direction picks asc/desc; a filter with no sort uses the
-        filtered profile (default relevance order, low-trust hits dropped).
+      * ``ranking_profile`` is always one of the ``RANK_PROFILE_*`` names — the
+        NIP-50 relay is TRUST-SORTED-WITHIN-TEXT by default (docs/search-vs-tapestry.md
+        §6), so with no sort token we use ``rank_desc`` rather than the
+        pure-text default profile that ``/search/byText`` uses. The sort
+        direction picks asc/desc; a filter with no sort uses the filtered
+        profile (pure-text order, low-trust hits dropped).
       * ``min_rank`` is the most restrictive lower bound across all filter
         tokens (``gte`` → value, ``gt`` → value + epsilon), or ``None`` when
         there's no filter. Vespa drops hits scoring below it.
@@ -303,7 +305,9 @@ def _select_ranking(
     elif min_rank is not None:
         profile = RANK_PROFILE_FILTERED
     else:
-        profile = None
+        # No sort, no filter: the NIP-50 default is trust-sorted-within-text,
+        # so default to rank_desc (NOT the pure-text /search/byText profile).
+        profile = RANK_PROFILE_SORT_DESC
 
     return profile, min_rank
 
@@ -440,9 +444,11 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
     # no Python re-ranking. See docs/search-precision-and-filtering.md.
     ranking_profile, min_rank = _select_ranking(sort_spec, filters)
 
-    # Ascending sort by trust wants the lowest-scoring docs first; the default
-    # "drop zero-score hits" would hide exactly those, so allow them here only.
-    ascending_sort = sort_spec is not None and sort_spec[1] == "asc"
+    # Trust-sorted-within-text INCLUDES unscored hits — they backfill below the
+    # trusted ones (mirroring tapestry's phase-2 backfill, docs/search-vs-tapestry.md
+    # §6). The only time we drop zero-score hits is when an explicit filter:rank
+    # cut-off is set, which means "only trusted profiles".
+    backfill_unscored = min_rank is None
 
     observer = observer_override or default_observer_pubkey()
 
@@ -458,7 +464,7 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
             query_text=query,
             user_pubkey=observer,
             hits=hits,
-            include_zero_score_results=ascending_sort,
+            include_zero_score_results=backfill_unscored,
             ranking_profile=ranking_profile,
             min_rank=min_rank,
         )

--- a/app/routers/open_ranking/capabilities.py
+++ b/app/routers/open_ranking/capabilities.py
@@ -1,0 +1,128 @@
+"""Open Ranking capability document (ORE-01) and algorithm-resolution logic.
+
+The capability doc is intentionally hand-written here rather than computed: it
+is the public protocol surface this provider commits to and changing it is a
+breaking change for clients.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.utils.observer import default_observer_pubkey
+
+
+# Endpoint -> ordered list of supported Algorithm Objects. The first element of
+# each list is the default algorithm for that endpoint (ORE-01 §"Algorithm
+# selection").
+CAPABILITY_DOC: dict[str, list[dict]] = {
+    "/stats/pubkey": [
+        {
+            "id": "graperank",
+            "name": "GrapeRank (global)",
+            "description": (
+                "GrapeRank from the provider's default observer. "
+                "Higher is more reputable."
+            ),
+        },
+        {
+            "id": "graperank-pov",
+            "name": "GrapeRank (personalized)",
+            "description": "GrapeRank computed from the provided pov pubkey.",
+            "pov": True,
+        },
+    ],
+    "/rank/pubkeys": [
+        {"id": "graperank", "name": "GrapeRank (global)"},
+        {"id": "graperank-pov", "name": "GrapeRank (personalized)", "pov": True},
+    ],
+    "/search/pubkeys": [
+        {
+            "id": "name-trust",
+            "name": "Name + Trust",
+            "description": (
+                "Profile text match (name / nip05 / about) weighted by the "
+                "provider's default observer GrapeRank."
+            ),
+        },
+        {
+            "id": "name-trust-pov",
+            "name": "Name + Trust (personalized)",
+            "description": "Same as name-trust, weighted by your own GrapeRank.",
+            "pov": True,
+        },
+    ],
+    "/followers": [
+        {"id": "graperank", "name": "GrapeRank (global)"},
+        {"id": "graperank-pov", "name": "GrapeRank (personalized)", "pov": True},
+    ],
+    "/muters": [
+        {"id": "graperank", "name": "GrapeRank (global)"},
+        {"id": "graperank-pov", "name": "GrapeRank (personalized)", "pov": True},
+    ],
+}
+
+
+# Algorithm ids that require a pov pubkey on the request. Kept in sync with the
+# CAPABILITY_DOC above — single source of truth for "is this personalized?".
+def _pov_required_ids() -> set[str]:
+    return {
+        algo["id"]
+        for algos in CAPABILITY_DOC.values()
+        for algo in algos
+        if algo.get("pov")
+    }
+
+
+_POV_REQUIRED: set[str] = _pov_required_ids()
+
+
+def resolve_algorithm(
+    endpoint: str,
+    requested: str | None,
+    pov: str | None,
+) -> tuple[str, str]:
+    """Apply ORE-01 algorithm-selection rules and return
+    `(algorithm_id, observer_pubkey)`.
+
+    - If `requested` is None, use the endpoint's default (first list element).
+    - If `requested` is not supported by the endpoint, raise 422.
+    - If the chosen algorithm requires a pov and none was provided, raise 422.
+    - For global algorithms, the observer is the provider's default observer.
+
+    Errors are signalled per the ORE error tables (HTTP 422 with an X-Reason
+    header attached upstream by the router layer).
+    """
+    algos = CAPABILITY_DOC.get(endpoint)
+    if algos is None:
+        # Programmer error rather than client error — endpoint isn't advertised
+        # in CAPABILITY_DOC but a handler called us anyway.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Endpoint {endpoint} not in capability document",
+        )
+
+    if requested is None:
+        algo = algos[0]
+    else:
+        algo = next((a for a in algos if a["id"] == requested), None)
+        if algo is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Algorithm '{requested}' is not supported by {endpoint}"
+                ),
+            )
+
+    if algo.get("pov"):
+        if not pov:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Algorithm '{algo['id']}' requires a 'pov' pubkey"
+                ),
+            )
+        return algo["id"], pov
+
+    # Global algorithm — pov MUST be ignored per ORE-01.
+    return algo["id"], default_observer_pubkey()

--- a/app/routers/open_ranking/capabilities.py
+++ b/app/routers/open_ranking/capabilities.py
@@ -81,6 +81,7 @@ def resolve_algorithm(
     endpoint: str,
     requested: str | None,
     pov: str | None,
+    forced_observer: str | None = None,
 ) -> tuple[str, str]:
     """Apply ORE-01 algorithm-selection rules and return
     `(algorithm_id, observer_pubkey)`.
@@ -89,6 +90,12 @@ def resolve_algorithm(
     - If `requested` is not supported by the endpoint, raise 422.
     - If the chosen algorithm requires a pov and none was provided, raise 422.
     - For global algorithms, the observer is the provider's default observer.
+
+    `forced_observer` is set when the provider runs in authenticated mode
+    (`settings.open_ranking_require_auth`): the observer is ALWAYS the
+    authenticated signer, so `pov` is ignored and a pov-requiring algorithm no
+    longer needs an explicit `pov`. The algorithm id is still validated so an
+    unsupported `algorithm` keeps returning 422.
 
     Errors are signalled per the ORE error tables (HTTP 422 with an X-Reason
     header attached upstream by the router layer).
@@ -113,6 +120,11 @@ def resolve_algorithm(
                     f"Algorithm '{requested}' is not supported by {endpoint}"
                 ),
             )
+
+    # Authenticated mode: the signer's own perspective overrides everything.
+    # pov is ignored and pov-requiring algorithms don't need an explicit pov.
+    if forced_observer is not None:
+        return algo["id"], forced_observer
 
     if algo.get("pov"):
         if not pov:

--- a/app/routers/open_ranking/common.py
+++ b/app/routers/open_ranking/common.py
@@ -1,0 +1,103 @@
+"""Shared helpers for the Open Ranking endpoints: pubkey validation, error
+responses with the ORE `X-Reason` header, and TTL hints.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
+
+
+HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Per-endpoint TTL hints (seconds). The protocol treats these as advisory.
+# Aligned with how frequently the underlying data changes:
+#   stats / rank / followers / muters -> GrapeRank cadence (hour-ish)
+#   search -> Vespa index updates near-real-time but profile churn matters less
+TTL_HINTS: dict[str, int] = {
+    "/stats/pubkey": 3600,
+    "/rank/pubkeys": 3600,
+    "/followers": 3600,
+    "/muters": 3600,
+    "/search/pubkeys": 300,
+}
+
+
+# Hard limits on batch / list sizes the spec recommends clients respect.
+MAX_BATCH_PUBKEYS = 1000
+MAX_LIMIT = 1000
+DEFAULT_RECOMMEND_LIMIT = 100
+MAX_QUERY_LEN = 512
+
+
+def validate_pubkey(value: str, field_name: str) -> str:
+    """Validate ORE-00 pubkey format (64-char lowercase hex) and return the
+    normalised value. Raises 422 on failure (per ORE-02/03 error tables).
+    """
+    if not isinstance(value, str):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{field_name} must be a 64-character lowercase hex string",
+        )
+    normalised = value.lower()
+    if not HEX64_RE.match(normalised):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{field_name} is not a valid 64-character lowercase hex pubkey",
+        )
+    return normalised
+
+
+def validate_pubkey_list(values: list[str], field_name: str) -> list[str]:
+    """Validate every entry in a list of pubkeys. Returns the normalised list."""
+    if not isinstance(values, list) or len(values) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{field_name} must be a non-empty array",
+        )
+    return [validate_pubkey(p, f"{field_name}[{i}]") for i, p in enumerate(values)]
+
+
+def enforce_batch_size(n: int) -> None:
+    """Enforce the ORE-03 / ORE-08 1000-pubkey soft cap with HTTP 413."""
+    if n > MAX_BATCH_PUBKEYS:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                f"Request exceeds the provider's limit of "
+                f"{MAX_BATCH_PUBKEYS} pubkeys per call"
+            ),
+        )
+
+
+def validate_positive_limit(
+    limit: int | None,
+    *,
+    field_name: str = "limit",
+    max_value: int = MAX_LIMIT,
+) -> int | None:
+    """Validate that an optional `limit` is a positive int within bounds."""
+    if limit is None:
+        return None
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{field_name} must be a positive integer",
+        )
+    if limit > max_value:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{field_name} exceeds the provider's maximum of {max_value}",
+        )
+    return limit
+
+
+def ore_error_response(status_code: int, reason: str) -> JSONResponse:
+    """Build a JSON error response with the ORE-00 `X-Reason` header set."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": reason},
+        headers={"X-Reason": reason},
+    )

--- a/app/routers/open_ranking/followers_muters.py
+++ b/app/routers/open_ranking/followers_muters.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import math
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.core.redis_db import redis_client
 from app.message_queue_tasks.process_strfry_event import (
@@ -29,6 +29,7 @@ from app.routers.open_ranking.schemas import (
     FollowersOrMutersResponse,
     RankResult,
 )
+from app.utils.auth.nwt import optional_nwt_signer
 
 
 router = APIRouter()
@@ -58,12 +59,15 @@ async def _top_inbound_response(
     relation: str,
     redis_prefix: str,
     req: FollowersOrMutersRequest,
+    signer: str | None,
 ) -> FollowersOrMutersResponse:
     pubkey = validate_pubkey(req.pubkey, "pubkey")
     pov = validate_pubkey(req.pov, "pov") if req.pov else None
     limit = validate_positive_limit(req.limit) or DEFAULT_LIMIT
 
-    _algo_id, observer = resolve_algorithm(endpoint, req.algorithm, pov)
+    _algo_id, observer = resolve_algorithm(
+        endpoint, req.algorithm, pov, forced_observer=signer
+    )
 
     # Fire the graph query and the Redis total count in parallel.
     async def _fetch_top() -> list:
@@ -94,12 +98,16 @@ async def _top_inbound_response(
     response_model=FollowersOrMutersResponse,
     summary="ORE-06: top-ranked followers of a pubkey",
 )
-async def followers(req: FollowersOrMutersRequest) -> FollowersOrMutersResponse:
+async def followers(
+    req: FollowersOrMutersRequest,
+    signer: str | None = Depends(optional_nwt_signer),
+) -> FollowersOrMutersResponse:
     return await _top_inbound_response(
         endpoint="/followers",
         relation="FOLLOWS",
         redis_prefix=FOLLOWED_BY_KEY_PREFIX,
         req=req,
+        signer=signer,
     )
 
 
@@ -108,10 +116,14 @@ async def followers(req: FollowersOrMutersRequest) -> FollowersOrMutersResponse:
     response_model=FollowersOrMutersResponse,
     summary="ORE-07: top-ranked muters of a pubkey",
 )
-async def muters(req: FollowersOrMutersRequest) -> FollowersOrMutersResponse:
+async def muters(
+    req: FollowersOrMutersRequest,
+    signer: str | None = Depends(optional_nwt_signer),
+) -> FollowersOrMutersResponse:
     return await _top_inbound_response(
         endpoint="/muters",
         relation="MUTES",
         redis_prefix=MUTED_BY_KEY_PREFIX,
         req=req,
+        signer=signer,
     )

--- a/app/routers/open_ranking/followers_muters.py
+++ b/app/routers/open_ranking/followers_muters.py
@@ -1,0 +1,117 @@
+"""ORE-06 (POST /followers) and ORE-07 (POST /muters).
+
+Both endpoints return the top-ranked inbound connections (FOLLOWS or MUTES
+edges) for a target pubkey, sorted by `influence_<observer>` DESC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+from fastapi import APIRouter
+
+from app.core.redis_db import redis_client
+from app.message_queue_tasks.process_strfry_event import (
+    FOLLOWED_BY_KEY_PREFIX,
+    MUTED_BY_KEY_PREFIX,
+)
+from app.neo4j_db.driver import driver as neo4j_driver
+from app.repos.user_repo import get_top_inbound_by_influence
+from app.routers.open_ranking.capabilities import resolve_algorithm
+from app.routers.open_ranking.common import (
+    TTL_HINTS,
+    validate_positive_limit,
+    validate_pubkey,
+)
+from app.routers.open_ranking.schemas import (
+    FollowersOrMutersRequest,
+    FollowersOrMutersResponse,
+    RankResult,
+)
+
+
+router = APIRouter()
+
+
+DEFAULT_LIMIT = 100  # sensible default per ORE-06/07
+
+
+def _safe_rank(value) -> float:
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(f) or math.isinf(f):
+        return 0.0
+    return f
+
+
+async def _redis_inbound_count(prefix: str, pubkey: str) -> int:
+    return int(await redis_client.scard(f"{prefix}{pubkey}"))
+
+
+async def _top_inbound_response(
+    endpoint: str,
+    relation: str,
+    redis_prefix: str,
+    req: FollowersOrMutersRequest,
+) -> FollowersOrMutersResponse:
+    pubkey = validate_pubkey(req.pubkey, "pubkey")
+    pov = validate_pubkey(req.pov, "pov") if req.pov else None
+    limit = validate_positive_limit(req.limit) or DEFAULT_LIMIT
+
+    _algo_id, observer = resolve_algorithm(endpoint, req.algorithm, pov)
+
+    # Fire the graph query and the Redis total count in parallel.
+    async def _fetch_top() -> list:
+        async with neo4j_driver.session() as session:
+            return await get_top_inbound_by_influence(
+                session, pubkey, observer, relation, limit
+            )
+
+    top, total = await asyncio.gather(
+        _fetch_top(),
+        _redis_inbound_count(redis_prefix, pubkey),
+    )
+
+    results = [
+        RankResult(pubkey=conn.pubkey, rank=_safe_rank(conn.influence))
+        for conn in top
+    ]
+
+    return FollowersOrMutersResponse(
+        results=results,
+        total=total,
+        ttl=TTL_HINTS[endpoint],
+    )
+
+
+@router.post(
+    "/followers",
+    response_model=FollowersOrMutersResponse,
+    summary="ORE-06: top-ranked followers of a pubkey",
+)
+async def followers(req: FollowersOrMutersRequest) -> FollowersOrMutersResponse:
+    return await _top_inbound_response(
+        endpoint="/followers",
+        relation="FOLLOWS",
+        redis_prefix=FOLLOWED_BY_KEY_PREFIX,
+        req=req,
+    )
+
+
+@router.post(
+    "/muters",
+    response_model=FollowersOrMutersResponse,
+    summary="ORE-07: top-ranked muters of a pubkey",
+)
+async def muters(req: FollowersOrMutersRequest) -> FollowersOrMutersResponse:
+    return await _top_inbound_response(
+        endpoint="/muters",
+        relation="MUTES",
+        redis_prefix=MUTED_BY_KEY_PREFIX,
+        req=req,
+    )

--- a/app/routers/open_ranking/rank.py
+++ b/app/routers/open_ranking/rank.py
@@ -1,0 +1,77 @@
+"""ORE-03: POST /rank/pubkeys."""
+
+from __future__ import annotations
+
+import math
+
+from fastapi import APIRouter
+
+from app.neo4j_db.driver import driver as neo4j_driver
+from app.repos.user_repo import batch_influence_for_pubkeys
+from app.routers.open_ranking.capabilities import resolve_algorithm
+from app.routers.open_ranking.common import (
+    TTL_HINTS,
+    enforce_batch_size,
+    validate_positive_limit,
+    validate_pubkey,
+    validate_pubkey_list,
+)
+from app.routers.open_ranking.schemas import (
+    RankPubkeysRequest,
+    RankPubkeysResponse,
+    RankResult,
+)
+
+
+router = APIRouter()
+
+
+def _safe_rank(value) -> float:
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(f) or math.isinf(f):
+        return 0.0
+    return f
+
+
+@router.post(
+    "/rank/pubkeys",
+    response_model=RankPubkeysResponse,
+    summary="ORE-03: rank a batch of pubkeys",
+)
+async def rank_pubkeys(req: RankPubkeysRequest) -> RankPubkeysResponse:
+    # 413 must fire BEFORE per-element validation (avoid 1000+ regex passes
+    # for an oversize payload).
+    if isinstance(req.pubkeys, list):
+        enforce_batch_size(len(req.pubkeys))
+
+    pubkeys = validate_pubkey_list(req.pubkeys, "pubkeys")
+    pov = validate_pubkey(req.pov, "pov") if req.pov else None
+    limit = validate_positive_limit(req.limit)
+
+    _algo_id, observer = resolve_algorithm("/rank/pubkeys", req.algorithm, pov)
+
+    # Default limit = number of pubkeys. Silently clamp larger limits down
+    # (per ORE-03 §"limit").
+    effective_limit = limit if limit is not None else len(pubkeys)
+    effective_limit = min(effective_limit, len(pubkeys))
+
+    async with neo4j_driver.session() as session:
+        influence_map = await batch_influence_for_pubkeys(
+            session, pubkeys, observer
+        )
+
+    # Build results: 0.0 for unknown / missing; sort DESC by rank then
+    # deterministic by pubkey for stable output across calls.
+    ranked = [
+        RankResult(pubkey=pk, rank=_safe_rank(influence_map.get(pk)))
+        for pk in pubkeys
+    ]
+    ranked.sort(key=lambda r: (-r.rank, r.pubkey))
+    ranked = ranked[:effective_limit]
+
+    return RankPubkeysResponse(results=ranked, ttl=TTL_HINTS["/rank/pubkeys"])

--- a/app/routers/open_ranking/rank.py
+++ b/app/routers/open_ranking/rank.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.neo4j_db.driver import driver as neo4j_driver
 from app.repos.user_repo import batch_influence_for_pubkeys
@@ -21,6 +21,7 @@ from app.routers.open_ranking.schemas import (
     RankPubkeysResponse,
     RankResult,
 )
+from app.utils.auth.nwt import optional_nwt_signer
 
 
 router = APIRouter()
@@ -43,7 +44,10 @@ def _safe_rank(value) -> float:
     response_model=RankPubkeysResponse,
     summary="ORE-03: rank a batch of pubkeys",
 )
-async def rank_pubkeys(req: RankPubkeysRequest) -> RankPubkeysResponse:
+async def rank_pubkeys(
+    req: RankPubkeysRequest,
+    signer: str | None = Depends(optional_nwt_signer),
+) -> RankPubkeysResponse:
     # 413 must fire BEFORE per-element validation (avoid 1000+ regex passes
     # for an oversize payload).
     if isinstance(req.pubkeys, list):
@@ -53,7 +57,9 @@ async def rank_pubkeys(req: RankPubkeysRequest) -> RankPubkeysResponse:
     pov = validate_pubkey(req.pov, "pov") if req.pov else None
     limit = validate_positive_limit(req.limit)
 
-    _algo_id, observer = resolve_algorithm("/rank/pubkeys", req.algorithm, pov)
+    _algo_id, observer = resolve_algorithm(
+        "/rank/pubkeys", req.algorithm, pov, forced_observer=signer
+    )
 
     # Default limit = number of pubkeys. Silently clamp larger limits down
     # (per ORE-03 §"limit").

--- a/app/routers/open_ranking/router.py
+++ b/app/routers/open_ranking/router.py
@@ -15,14 +15,13 @@ implemented and are intentionally absent from the capability document.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 
 from app.routers.open_ranking.followers_muters import router as followers_muters_router
 from app.routers.open_ranking.rank import router as rank_router
 from app.routers.open_ranking.search import router as search_router
 from app.routers.open_ranking.stats import router as stats_router
 from app.routers.open_ranking.well_known import router as well_known_router
-from app.utils.auth.nwt import verify_nwt
 
 
 router = APIRouter()
@@ -30,10 +29,10 @@ router = APIRouter()
 # Capability document MUST be discoverable without auth (ORE-01).
 router.include_router(well_known_router)
 
-# Every data endpoint requires a valid NWT (ORE-A). The expected audience is
-# derived from settings.public_base_url inside the verifier.
-_auth_dep = [Depends(verify_nwt)]
-router.include_router(stats_router, dependencies=_auth_dep)
-router.include_router(rank_router, dependencies=_auth_dep)
-router.include_router(search_router, dependencies=_auth_dep)
-router.include_router(followers_muters_router, dependencies=_auth_dep)
+# Auth posture is per-request and toggled by settings.open_ranking_require_auth:
+# each data handler depends on `optional_nwt_signer`, which enforces the NWT
+# (ORE-A) only when auth is enabled. See app/utils/auth/nwt.py.
+router.include_router(stats_router)
+router.include_router(rank_router)
+router.include_router(search_router)
+router.include_router(followers_muters_router)

--- a/app/routers/open_ranking/router.py
+++ b/app/routers/open_ranking/router.py
@@ -1,0 +1,39 @@
+"""Aggregator for the Open Ranking provider router.
+
+Endpoints exposed (all root-mounted — the protocol mandates exact paths):
+
+- GET  /.well-known/open-ranking.json   (ORE-01)
+- POST /stats/pubkey                     (ORE-02)
+- POST /rank/pubkeys                     (ORE-03)
+- POST /search/pubkeys                   (ORE-05)
+- POST /followers                        (ORE-06)
+- POST /muters                           (ORE-07)
+
+ORE-04 (recommendations) and ORE-08 (compromised pubkeys) are not yet
+implemented and are intentionally absent from the capability document.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.routers.open_ranking.followers_muters import router as followers_muters_router
+from app.routers.open_ranking.rank import router as rank_router
+from app.routers.open_ranking.search import router as search_router
+from app.routers.open_ranking.stats import router as stats_router
+from app.routers.open_ranking.well_known import router as well_known_router
+from app.utils.auth.nwt import verify_nwt
+
+
+router = APIRouter()
+
+# Capability document MUST be discoverable without auth (ORE-01).
+router.include_router(well_known_router)
+
+# Every data endpoint requires a valid NWT (ORE-A). The expected audience is
+# derived from settings.public_base_url inside the verifier.
+_auth_dep = [Depends(verify_nwt)]
+router.include_router(stats_router, dependencies=_auth_dep)
+router.include_router(rank_router, dependencies=_auth_dep)
+router.include_router(search_router, dependencies=_auth_dep)
+router.include_router(followers_muters_router, dependencies=_auth_dep)

--- a/app/routers/open_ranking/schemas.py
+++ b/app/routers/open_ranking/schemas.py
@@ -1,0 +1,80 @@
+"""Pydantic request / response schemas for the Open Ranking endpoints
+(ORE-02..ORE-07). Field names match the spec exactly — do not rename.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+# ---- ORE-02: /stats/pubkey ----
+
+
+class StatsPubkeyRequest(BaseModel):
+    pubkey: str
+    algorithm: str | None = None
+    pov: str | None = None
+
+
+class StatsPubkeyResponse(BaseModel):
+    pubkey: str
+    rank: float
+    follows: int | None = None
+    followers: int | None = None
+    mutes: int | None = None
+    muters: int | None = None
+    reports: int | None = None
+    reporters: int | None = None
+    first_seen_at: int | None = None
+    ttl: int | None = None
+
+
+# ---- ORE-03: /rank/pubkeys ----
+
+
+class RankPubkeysRequest(BaseModel):
+    pubkeys: list[str]
+    algorithm: str | None = None
+    pov: str | None = None
+    limit: int | None = None
+
+
+class RankResult(BaseModel):
+    pubkey: str
+    rank: float
+
+
+class RankPubkeysResponse(BaseModel):
+    results: list[RankResult]
+    ttl: int | None = None
+
+
+# ---- ORE-05: /search/pubkeys ----
+
+
+class SearchPubkeysRequest(BaseModel):
+    query: str
+    algorithm: str | None = None
+    pov: str | None = None
+    limit: int | None = None
+
+
+class SearchPubkeysResponse(BaseModel):
+    results: list[RankResult]
+    ttl: int | None = None
+
+
+# ---- ORE-06 / ORE-07: /followers and /muters ----
+
+
+class FollowersOrMutersRequest(BaseModel):
+    pubkey: str
+    algorithm: str | None = None
+    pov: str | None = None
+    limit: int | None = None
+
+
+class FollowersOrMutersResponse(BaseModel):
+    results: list[RankResult]
+    total: int | None = None
+    ttl: int | None = None

--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -1,0 +1,91 @@
+"""ORE-05: POST /search/pubkeys."""
+
+from __future__ import annotations
+
+import math
+import re
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.core.vespa import search as vespa_search
+from app.routers.open_ranking.capabilities import resolve_algorithm
+from app.routers.open_ranking.common import (
+    MAX_QUERY_LEN,
+    TTL_HINTS,
+    validate_positive_limit,
+    validate_pubkey,
+)
+from app.routers.open_ranking.schemas import (
+    RankResult,
+    SearchPubkeysRequest,
+    SearchPubkeysResponse,
+)
+
+
+router = APIRouter()
+
+
+DEFAULT_LIMIT = 100  # provider default per ORE-05 §"limit"
+MAX_LIMIT = 400  # mirrors the existing /search/byText cap
+
+# Strip control characters; keep printable text only.
+_SANITIZE_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _safe_rank(value) -> float:
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(f) or math.isinf(f):
+        return 0.0
+    return f
+
+
+@router.post(
+    "/search/pubkeys",
+    response_model=SearchPubkeysResponse,
+    summary="ORE-05: search Nostr profiles by free-form text",
+)
+async def search_pubkeys(req: SearchPubkeysRequest) -> SearchPubkeysResponse:
+    if not isinstance(req.query, str) or not req.query.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="query field is missing or empty",
+        )
+    if len(req.query) > MAX_QUERY_LEN:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"query exceeds the maximum length of {MAX_QUERY_LEN} characters",
+        )
+
+    pov = validate_pubkey(req.pov, "pov") if req.pov else None
+    limit = validate_positive_limit(req.limit, max_value=MAX_LIMIT) or DEFAULT_LIMIT
+
+    _algo_id, observer = resolve_algorithm("/search/pubkeys", req.algorithm, pov)
+    sanitized = _SANITIZE_RE.sub("", req.query).strip()
+
+    # Vespa returns documents with `_quality_score` (the observer's score for
+    # the matched profile). That score IS the rank for ORE-05.
+    hits = await vespa_search(
+        query_text=sanitized,
+        user_pubkey=observer,
+        hits=limit,
+        include_zero_score_results=True,
+    )
+
+    results: list[RankResult] = []
+    for h in hits:
+        pk = h.get("pubkey")
+        if not isinstance(pk, str):
+            continue
+        results.append(
+            RankResult(pubkey=pk, rank=_safe_rank(h.get("_quality_score")))
+        )
+
+    return SearchPubkeysResponse(
+        results=results,
+        ttl=TTL_HINTS["/search/pubkeys"],
+    )

--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import re
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.core.vespa import search as vespa_search
 from app.routers.open_ranking.capabilities import resolve_algorithm
@@ -20,6 +20,7 @@ from app.routers.open_ranking.schemas import (
     SearchPubkeysRequest,
     SearchPubkeysResponse,
 )
+from app.utils.auth.nwt import optional_nwt_signer
 
 
 router = APIRouter()
@@ -49,7 +50,10 @@ def _safe_rank(value) -> float:
     response_model=SearchPubkeysResponse,
     summary="ORE-05: search Nostr profiles by free-form text",
 )
-async def search_pubkeys(req: SearchPubkeysRequest) -> SearchPubkeysResponse:
+async def search_pubkeys(
+    req: SearchPubkeysRequest,
+    signer: str | None = Depends(optional_nwt_signer),
+) -> SearchPubkeysResponse:
     if not isinstance(req.query, str) or not req.query.strip():
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -64,7 +68,9 @@ async def search_pubkeys(req: SearchPubkeysRequest) -> SearchPubkeysResponse:
     pov = validate_pubkey(req.pov, "pov") if req.pov else None
     limit = validate_positive_limit(req.limit, max_value=MAX_LIMIT) or DEFAULT_LIMIT
 
-    _algo_id, observer = resolve_algorithm("/search/pubkeys", req.algorithm, pov)
+    _algo_id, observer = resolve_algorithm(
+        "/search/pubkeys", req.algorithm, pov, forced_observer=signer
+    )
     sanitized = _SANITIZE_RE.sub("", req.query).strip()
 
     # Vespa returns documents with `_quality_score` (the observer's score for

--- a/app/routers/open_ranking/stats.py
+++ b/app/routers/open_ranking/stats.py
@@ -1,0 +1,62 @@
+"""ORE-02: POST /stats/pubkey."""
+
+from __future__ import annotations
+
+import math
+
+from fastapi import APIRouter
+
+from app.routers.open_ranking.capabilities import resolve_algorithm
+from app.routers.open_ranking.common import TTL_HINTS, validate_pubkey
+from app.routers.open_ranking.schemas import (
+    StatsPubkeyRequest,
+    StatsPubkeyResponse,
+)
+from app.services.user_service import get_user_overview
+
+
+router = APIRouter()
+
+
+def _safe_rank(value) -> float:
+    """Coerce Neo4j influence to a JSON-safe number. Unknown / null / non-
+    finite values become 0.0 — semantically "no observed trust" for the
+    GrapeRank family of algorithms.
+    """
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(f) or math.isinf(f):
+        return 0.0
+    return f
+
+
+@router.post(
+    "/stats/pubkey",
+    response_model=StatsPubkeyResponse,
+    summary="ORE-02: rank + stats for a single pubkey",
+)
+async def stats_pubkey(req: StatsPubkeyRequest) -> StatsPubkeyResponse:
+    pubkey = validate_pubkey(req.pubkey, "pubkey")
+    pov = validate_pubkey(req.pov, "pov") if req.pov else None
+
+    _algo_id, observer = resolve_algorithm("/stats/pubkey", req.algorithm, pov)
+
+    overview = await get_user_overview(pubkey=pubkey, observer=observer)
+    counts = overview.counts
+
+    return StatsPubkeyResponse(
+        pubkey=pubkey,
+        rank=_safe_rank(overview.influence),
+        follows=counts.following,
+        followers=counts.followed_by,
+        mutes=counts.muting,
+        muters=counts.muted_by,
+        reports=counts.reporting,
+        reporters=counts.reported_by,
+        # `first_seen_at` is not tracked yet — omit (the field is optional).
+        ttl=TTL_HINTS["/stats/pubkey"],
+    )

--- a/app/routers/open_ranking/stats.py
+++ b/app/routers/open_ranking/stats.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.routers.open_ranking.capabilities import resolve_algorithm
 from app.routers.open_ranking.common import TTL_HINTS, validate_pubkey
@@ -13,6 +13,7 @@ from app.routers.open_ranking.schemas import (
     StatsPubkeyResponse,
 )
 from app.services.user_service import get_user_overview
+from app.utils.auth.nwt import optional_nwt_signer
 
 
 router = APIRouter()
@@ -39,11 +40,16 @@ def _safe_rank(value) -> float:
     response_model=StatsPubkeyResponse,
     summary="ORE-02: rank + stats for a single pubkey",
 )
-async def stats_pubkey(req: StatsPubkeyRequest) -> StatsPubkeyResponse:
+async def stats_pubkey(
+    req: StatsPubkeyRequest,
+    signer: str | None = Depends(optional_nwt_signer),
+) -> StatsPubkeyResponse:
     pubkey = validate_pubkey(req.pubkey, "pubkey")
     pov = validate_pubkey(req.pov, "pov") if req.pov else None
 
-    _algo_id, observer = resolve_algorithm("/stats/pubkey", req.algorithm, pov)
+    _algo_id, observer = resolve_algorithm(
+        "/stats/pubkey", req.algorithm, pov, forced_observer=signer
+    )
 
     overview = await get_user_overview(pubkey=pubkey, observer=observer)
     counts = overview.counts

--- a/app/routers/open_ranking/well_known.py
+++ b/app/routers/open_ranking/well_known.py
@@ -1,0 +1,25 @@
+"""ORE-01 capability document endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.routers.open_ranking.capabilities import CAPABILITY_DOC
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/.well-known/open-ranking.json",
+    summary="Open Ranking capability document (ORE-01)",
+)
+async def open_ranking_capability_document() -> JSONResponse:
+    # Explicitly construct JSONResponse so we control the Content-Type and can
+    # set the CORS header per ORE-00 even if global CORS middleware misses it
+    # (e.g. on non-Origin requests).
+    return JSONResponse(
+        content=CAPABILITY_DOC,
+        headers={"Access-Control-Allow-Origin": "*"},
+    )

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -6,6 +6,7 @@ from app.core.database import get_db
 from app.routers.admin.router import router as admin_router
 from app.routers.auth_challenge.router import router as auth_challenge_router
 from app.routers.graperank.router import router as graperank_router
+from app.routers.nip50.router import router as nip50_router
 from app.routers.open_ranking.router import router as open_ranking_router
 from app.routers.search.router import router as search_router
 from app.routers.setup.router import router as setup_router
@@ -62,6 +63,14 @@ router.include_router(
     router=search_router,
     prefix=SEARCH_ROUTER_PREFIX,
     tags=["search"],
+)
+
+# NIP-50 search relay. Mounted at root because NIP-11 mandates the
+# information document live at the same URL clients connect to over
+# WebSocket — here that's ``/relay``.
+router.include_router(
+    router=nip50_router,
+    tags=["nip50"],
 )
 
 USER_ROUTER_PREFIX = "/user"

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -6,6 +6,7 @@ from app.core.database import get_db
 from app.routers.admin.router import router as admin_router
 from app.routers.auth_challenge.router import router as auth_challenge_router
 from app.routers.graperank.router import router as graperank_router
+from app.routers.open_ranking.router import router as open_ranking_router
 from app.routers.search.router import router as search_router
 from app.routers.setup.router import router as setup_router
 from app.routers.user.router import router as user_router
@@ -21,6 +22,15 @@ from app.utils.api_validators import verify_token
 from sqlalchemy.ext.asyncio import AsyncSession as AsyncDBSession
 
 router = APIRouter()
+
+# Open Ranking provider (OREs 01/02/03/05/06/07). Mounted at root because the
+# protocol mandates exact paths (e.g. /.well-known/open-ranking.json,
+# /stats/pubkey, /rank/pubkeys, ...). Authentication is currently optional;
+# ORE-A (NWT) wiring lives in a follow-up phase.
+router.include_router(
+    router=open_ranking_router,
+    tags=["open-ranking"],
+)
 
 ADMIN_ROUTER_PREFIX = "/admin"
 

--- a/app/routers/search/router.py
+++ b/app/routers/search/router.py
@@ -81,8 +81,9 @@ async def search_by_text_endpoint(
         doc = await get_document(pubkey)
         results = [doc] if doc is not None else []
     else:
-        # name_and_quality_score_only already orders by quality_boost-weighted
-        # relevance, so we don't need a client-side rank-based re-sort.
+        # The default text_relevance profile orders by PURE TEXT relevance
+        # (P0, docs/search-vs-tapestry.md §6) — trust is no longer blended in —
+        # so we don't need a client-side rank-based re-sort.
         results = await search(
             query_text=sanitized,
             user_pubkey=observer,

--- a/app/routers/search/router.py
+++ b/app/routers/search/router.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from nostr_sdk import PublicKey
 
-from app.core.vespa import get_document, search
+from app.core.vespa import DEFAULT_MIN_RANK, SORT_PROFILES, get_document, search
 from app.schemas.request_response_schemas import (
     SearchByTextResponse,
     SearchResults,
@@ -64,9 +64,31 @@ async def search_by_text_endpoint(
             f"{RESULTS_LIMIT}; larger values are clamped down."
         ),
     ),
+    sort: str = Query(
+        default="followers",
+        description=(
+            "Sort order: 'followers' (default — verified-follower count, "
+            "popular-first), 'rank' (observer trust), or 'text' (pure text "
+            "relevance). All apply the rank>=minRank filter. See "
+            "docs/search-vs-tapestry.md §8.1."
+        ),
+    ),
+    minRank: float = Query(
+        default=DEFAULT_MIN_RANK,
+        ge=0,
+        description=(
+            "Exclude profiles whose observer rank (influence*100) is below this. "
+            f"Default {int(DEFAULT_MIN_RANK)}."
+        ),
+    ),
     jwt_data: Optional[JWTData] = Depends(verify_token_optional),
 ) -> SearchByTextResponse:
     sanitized = _sanitize(text)
+    if sort not in SORT_PROFILES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"sort must be one of {sorted(SORT_PROFILES)}",
+        )
     observer = default_observer_pubkey()
     if ownPubkey:
         if jwt_data is None:
@@ -81,14 +103,16 @@ async def search_by_text_endpoint(
         doc = await get_document(pubkey)
         results = [doc] if doc is not None else []
     else:
-        # The default text_relevance profile orders by PURE TEXT relevance
-        # (P0, docs/search-vs-tapestry.md §6) — trust is no longer blended in —
-        # so we don't need a client-side rank-based re-sort.
+        # Default: text match -> filter rank>=minRank -> sort by verified
+        # followers (docs/search-vs-tapestry.md §8.1). `sort` picks the profile;
+        # the rank filter is applied via min_rank for every sort mode.
         results = await search(
             query_text=sanitized,
             user_pubkey=observer,
             hits=min(maxHits, RESULTS_LIMIT),
             include_zero_score_results=not onlyRanked,
+            ranking_profile=SORT_PROFILES[sort],
+            min_rank=minRank,
         )
 
     return SearchByTextResponse(

--- a/app/utils/auth/nwt.py
+++ b/app/utils/auth/nwt.py
@@ -177,11 +177,20 @@ def _extract_nwt_from_header(request: Request) -> Optional[str]:
     return token.strip()
 
 
-async def verify_nwt(request: Request) -> str:
-    """FastAPI dependency: REQUIRE a valid NWT, return the signer pubkey.
+async def optional_nwt_signer(request: Request) -> Optional[str]:
+    """FastAPI dependency honouring `settings.open_ranking_require_auth`.
 
-    Every Open Ranking endpoint depends on this — there is no anonymous mode.
+    - Auth enforced (flag True): REQUIRE a valid NWT and return the signer's
+      pubkey. Handlers force the observer perspective to this pubkey, so a
+      caller can only ever query their own scores.
+    - Open mode (flag False): return None. No NWT is required; handlers fall
+      back to the public global observer plus any client-supplied `pov`.
+
+    Returning the signer (or None) lets each handler decide how to resolve the
+    observer without re-reading the header.
     """
+    if not settings.open_ranking_require_auth:
+        return None
     token = _extract_nwt_from_header(request)
     if not token:
         raise _unauthorized("Missing Authorization: Nostr <token> header")

--- a/app/utils/auth/nwt.py
+++ b/app/utils/auth/nwt.py
@@ -1,0 +1,188 @@
+"""ORE-A: Nostr Web Tokens (NWT) verification.
+
+NWT is a signed Nostr event of kind 27519 conveying signed claims from a client
+to an Open Ranking provider. Claims are carried as event tags:
+
+    ["aud",  "<provider-domain>"]   required when the provider enforces audience
+    ["iat",  "<unix-seconds>"]      issued-at, optional but sanity-checked
+    ["nbf",  "<unix-seconds>"]      not-before, optional
+    ["exp",  "<unix-seconds>"]      expiry, optional but strongly recommended
+
+Transport per ORE-A: `Authorization: Nostr <base64url-no-padding-token>` where
+the token is the JSON-serialized signed event.
+
+Reference: https://github.com/Open-Ranking/nostr-web-tokens
+
+This validator is independent of the existing NIP-98 (kind 27235) validator;
+it deliberately does NOT check `method`, `u`, or `payload` tags.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request, status
+from nostr_sdk import Event
+
+from app.core.config import settings
+
+
+NWT_KIND = 27519
+
+# Recommended clock skew per the NWT spec ("Verifiers SHOULD allow a small
+# clock skew, e.g. ±60 seconds"). Applied symmetrically to nbf / exp and as
+# the forward bound on iat / created_at.
+NWT_CLOCK_SKEW_SECONDS = 60
+
+
+def _expected_audience() -> str:
+    """The audience this provider identifies as for the purposes of the NWT
+    `aud` claim. Derived from `settings.public_base_url` so it stays in sync
+    with the hostname clients reach us at — no separate env var needed.
+    """
+    parsed = urlparse(settings.public_base_url)
+    # `netloc` returns "host:port"; the spec is hostname-oriented so strip
+    # the port. Falls back to the raw value if the URL is unparseable.
+    if parsed.hostname:
+        return parsed.hostname
+    return settings.public_base_url
+
+
+def _b64url_decode_no_pad(value: str) -> bytes:
+    """Decode an unpadded base64url string. NWT mandates no padding."""
+    s = value.strip()
+    # `base64.urlsafe_b64decode` requires correct padding; pad to a multiple of 4.
+    padding = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * padding))
+
+
+def _find_tag_value(event: Event, name: str) -> Optional[str]:
+    """Return the FIRST value for the named tag, or None."""
+    for tag in event.tags().to_vec():
+        vec = tag.as_vec()
+        if len(vec) >= 2 and vec[0] == name:
+            return vec[1]
+    return None
+
+
+def _find_tag_values(event: Event, name: str) -> list[str]:
+    """Return ALL values for the named tag. The NWT spec allows a token to
+    carry multiple `aud` tags (one per intended recipient); a verifier
+    accepts the token when ANY of them matches.
+    """
+    out: list[str] = []
+    for tag in event.tags().to_vec():
+        vec = tag.as_vec()
+        if len(vec) >= 2 and vec[0] == name:
+            out.append(vec[1])
+    return out
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    # ORE-A defers HTTP error codes to the NWT spec. 401 is the canonical
+    # "invalid or missing credentials" choice; X-Reason carries the human-
+    # readable reason and is attached by the FastAPI exception handler.
+    exc = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+    exc.headers = {"X-Reason": detail, "WWW-Authenticate": "Nostr"}
+    return exc
+
+
+def _bad_token(detail: str) -> HTTPException:
+    exc = HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+    exc.headers = {"X-Reason": detail, "WWW-Authenticate": "Nostr"}
+    return exc
+
+
+def _parse_unix_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def validate_nwt_token(encoded_token: str) -> str:
+    """Validate the value of an `Authorization: Nostr <token>` header.
+
+    Returns the signer's pubkey (hex) on success. Raises HTTPException with
+    `X-Reason` on any failure.
+    """
+    try:
+        decoded = _b64url_decode_no_pad(encoded_token).decode("utf-8")
+    except Exception:
+        raise _unauthorized("Bad NWT: invalid base64url")
+
+    try:
+        event = Event.from_json(decoded)
+    except Exception:
+        raise _unauthorized("Bad NWT: invalid event JSON")
+
+    if event.kind().as_u16() != NWT_KIND:
+        raise _unauthorized(f"Bad NWT: expected kind {NWT_KIND}")
+
+    if not event.verify_signature():
+        raise _unauthorized("Bad NWT: invalid signature")
+
+    now = int(datetime.now(tz=timezone.utc).timestamp())
+
+    # Issued-at sanity. Per spec, when `iat` is present verifiers MUST use it
+    # in place of `created_at`. If neither is acceptable as a "not too far in
+    # the future" value, the token is rejected — defends against tokens whose
+    # validity window is shifted forward by clock manipulation.
+    iat_tag = _parse_unix_int(_find_tag_value(event, "iat"))
+    issued_at = iat_tag if iat_tag is not None else event.created_at().as_secs()
+    if issued_at - now > NWT_CLOCK_SKEW_SECONDS:
+        raise _bad_token("Bad NWT: iat is in the future")
+
+    # nbf: token not yet valid. Allow clock skew so a clock-drifted client
+    # whose nbf is a few seconds ahead of the server still goes through.
+    nbf = _parse_unix_int(_find_tag_value(event, "nbf"))
+    if nbf is not None and now + NWT_CLOCK_SKEW_SECONDS < nbf:
+        raise _bad_token("Bad NWT: token not yet valid (nbf)")
+
+    # exp: token expired. Same symmetric skew.
+    exp = _parse_unix_int(_find_tag_value(event, "exp"))
+    if exp is not None and now - NWT_CLOCK_SKEW_SECONDS >= exp:
+        raise _bad_token("Bad NWT: token expired (exp)")
+
+    # Audience check. The NWT spec allows MULTIPLE `aud` tags on a single
+    # token — accept the token when ANY of them matches this provider. The
+    # expected audience is the hostname of the provider's public_base_url.
+    expected_aud = _expected_audience()
+    aud_values = _find_tag_values(event, "aud")
+    if not aud_values:
+        raise _bad_token("Bad NWT: missing aud claim")
+    if expected_aud not in aud_values:
+        raise _bad_token(
+            f"Bad NWT: aud {aud_values} does not include this provider"
+        )
+
+    return event.author().to_hex()
+
+
+def _extract_nwt_from_header(request: Request) -> Optional[str]:
+    """Pull the NWT token out of `Authorization: Nostr <token>`. Returns
+    None if the header is absent or uses a different scheme.
+    """
+    header = request.headers.get("authorization")
+    if not header:
+        return None
+    scheme, _, token = header.strip().partition(" ")
+    if scheme.lower() != "nostr" or not token:
+        return None
+    return token.strip()
+
+
+async def verify_nwt(request: Request) -> str:
+    """FastAPI dependency: REQUIRE a valid NWT, return the signer pubkey.
+
+    Every Open Ranking endpoint depends on this — there is no anonymous mode.
+    """
+    token = _extract_nwt_from_header(request)
+    if not token:
+        raise _unauthorized("Missing Authorization: Nostr <token> header")
+    return validate_nwt_token(token)

--- a/docs/search-precision-and-filtering.md
+++ b/docs/search-precision-and-filtering.md
@@ -1,0 +1,218 @@
+# Search precision + NIP-50 filtering: problems & fixes
+
+_Last updated: 2026-06-27. Owner: search. Audience: the team — read this before
+touching `app/core/vespa.py`, the NIP-50 relay, or the Vespa schema._
+
+This note covers two related changes that landed together because they touch the
+same files (`app/core/vespa.py` and the Vespa `doc.sd` schema):
+
+1. **Precision fix** — exact-match search was being polluted by typo-correction
+   and trigram recall. See "Problem 1".
+2. **Sort/filter push-down** — the NIP-50 `sort:`/`filter:` extensions were
+   prototyped as Python post-processing over an over-fetched candidate set. We
+   moved that work into Vespa rank profiles. See "Problem 2".
+
+> **Where the schema lives.** The *deployed* Vespa schema is
+> `nosfabrica-kube/charts/brainstorm/vespa-app/schemas/doc.sd`, shipped via a
+> Helm ConfigMap + a post-install/upgrade Job that POSTs the app package to the
+> Vespa config server (see `charts/brainstorm/templates/vespa-app-deploy.yaml`
+> and `charts/brainstorm/VESPA.md`). The copy under
+> `brainstorm_one_click_deployment/vespa-app/` is **stale** (it predates the
+> NaN-guard fix) — treat the kube repo as source of truth.
+
+---
+
+## Problem 1 — garbage in results; exact matching suffers
+
+### Symptom
+
+Searches return loosely-related junk, and exact-name queries don't reliably put
+the exact match on top. It looked like "typo correction gone wrong" — and that's
+half the story.
+
+### Root causes
+
+The query builder in `app/core/vespa.py` OR-s several recall-wideners into the
+Vespa `where` clause. Three of them are responsible, and two also feed the
+ranking score:
+
+1. **Fuzzy matching was too loose.** `_word_max_edits()` allowed
+   `maxEditDistance: 2` for words ≥ 6 chars, with `prefixLength: 1`. A single
+   leading character plus "within two edits" pulls in a large cloud of unrelated
+   names (an 8-char query can match hundreds of docs).
+
+2. **`matchCount()` does not distinguish exact from fuzzy.** The ranking's
+   dominant term is `matchCount(name) * 100`, but Vespa counts a *fuzzy* or
+   *prefix* match toward `matchCount` exactly like an exact one. So a document
+   matched two edits away earns the **same `+100`** as a genuine exact hit —
+   which is why "exact matching suffers": after that term, only `bm25` and the
+   trigram score break the tie, and those can favor the wrong doc.
+
+3. **Trigram OR is a firehose.** `_gram_clause()` builds `(g1 or g2 or …)` over
+   a word's trigrams against `name_gram`/`display_name_gram`. **Any single
+   shared 3-character sequence** qualifies a doc into the candidate set
+   ("robert" shares `rob/obe/ber/ert` with many unrelated names).
+
+4. **The trigram weight let recall-helpers outrank exact matches.** In
+   `search()`, `query(w_gram)` was **20.0** for short queries / 5.0 otherwise,
+   and `name_text` adds `query(w_gram) * bm25(name_gram)`. At `w_gram = 20`, a
+   trigram-only match (`matchCount = 0`) could score higher than a real exact
+   token match. Trigrams are meant to be a recall safety-net and tie-breaker —
+   not a primary ranking signal.
+
+### Fix (the "Option A" tuning)
+
+Conservative knob changes plus one structural guarantee. All low-risk; no
+re-feed required (see "Deploying schema changes").
+
+**In `app/core/vespa.py`:**
+
+- `_word_max_edits()` — cap the fuzzy budget at **1 edit**, and only for words
+  **≥ 4 chars**. One-edit typos are still corrected; the "within-2-of-anything"
+  cloud is gone.
+- `_field_clauses()` — fuzzy `prefixLength: 1 → 2`. The first two characters must
+  match exactly, so a typo in char ≥ 3 is still tolerated but a wrong first/second
+  letter no longer drags in noise.
+- `search()` — lower `query(w_gram)` defaults (short-query / long-query). Trigrams
+  remain meaningful for very short queries where token matching can't fire, but
+  stop dominating longer queries.
+
+**In `doc.sd` (`name_and_quality_score_only`):**
+
+- Add a `query(gram_cap)` input and cap the trigram contribution:
+  `+ min(query(w_gram) * bm25(name_gram), query(gram_cap))` in `name_text` and
+  the equivalent in `display_name_text`. With `gram_cap` < 100, a trigram-only
+  match can **never** outscore a single exact token match (`matchCount * 100`).
+  This makes "exact beats trigram" a guarantee, not a tuning accident.
+
+### Known limitation / future "Option B"
+
+Cause #2 above is only *mitigated*, not eliminated: with fuzzy tightened to
+1 edit + `prefixLength: 2`, a fuzzy hit is genuinely close, so it sharing the
+`+100` with an exact hit is acceptable. If we later need exact to **strictly**
+beat any fuzzy hit, we have to separate the two at match time — e.g. keep the
+loose clause for recall but score a dedicated non-fuzzy clause separately (Vespa
+`rank()` operator), or add an explicit full-exact-match bonus. That's a larger
+change to `_build_yql` + the rank profile and is deferred.
+
+### How to tune safely
+
+These knobs interact. Do **not** eyeball them — tune against a fixed set of
+`query → expected pubkey` pairs (the real garbage cases) run against a live
+Vespa. Add cases as new garbage is reported.
+
+---
+
+## Problem 2 — NIP-50 `sort:` / `filter:` were going to run in Python
+
+### Why Python post-processing was the wrong home
+
+The per-observer `rank` metric is **not a stored field**. In `doc.sd` it is
+computed at query time:
+
+```
+function user_score() {
+    expression: sum(query(user_q) * attribute(quality_scores))
+}
+```
+
+— a dot-product over the sparse `quality_scores` tensor, selecting the cell for
+the observer passed in `query(user_q)`. Vespa can *rank* by that expression, but
+a YQL `where` clause cannot *filter* on it, and there is no single attribute to
+`order by`. The prototype therefore over-fetched (`EXTENSION_OVERFETCH = 200`)
+and re-sorted/filtered in Python (`_apply_filters_and_sort`), because the
+top-N by text relevance is not the same set as the top-N by rank, nor the subset
+passing `rank ≥ N`.
+
+That works but is wasteful and fragile (over-fetch tuning, double work, the app
+re-implementing ranking). We pushed it into Vespa instead.
+
+### The fix — dedicated rank profiles
+
+`doc.sd` gains three profiles that inherit `name_and_quality_score_only` (so
+`user_score()`, `relevance()`, the inputs, and match-features carry over):
+
+| Profile | first-phase ordering | Used for |
+|---|---|---|
+| `rank_filtered` | default `relevance()` | `filter:` with no `sort:` |
+| `rank_desc` | `user_score()` | `sort:rank:desc` (± filter) |
+| `rank_asc` | `-1 * user_score()` (Vespa always orders desc) | `sort:rank:asc` (± filter) |
+
+**Sorting** is just "make the metric the first-phase expression," so Vespa's
+top-N *is* the answer — the over-fetch disappears and the server asks for exactly
+`hits`.
+
+**Filtering** uses a per-query threshold. Each profile gates on a shared
+`query(min_rank)` input:
+
+```
+first-phase {
+    expression: if(user_score() >= query(min_rank), <ordering>, -1e9)
+    rank-score-drop-limit: -1e6
+}
+```
+
+A hit failing the threshold is mapped to a sentinel (`-1e9`) far below
+`rank-score-drop-limit` (`-1e6`), so Vespa drops it server-side. Real scores live
+in `[-100, 1000]`, so the wide sentinel gap means the exact `<` vs `<=` drop
+semantics never affect a real hit. `query(min_rank)` defaults to a value below
+every real score, so the gate is a no-op unless a request sets it.
+
+### Server wiring
+
+`app/core/vespa.py::search()` gained `ranking_profile` + `min_rank` kwargs that
+plumb straight to Vespa query params (`ranking=…`,
+`ranking.features.query(min_rank)=…`). The NIP-50 relay
+(`app/routers/nip50/router.py`) maps tokens → profile:
+
+| Client tokens | `ranking_profile` | `min_rank` |
+|---|---|---|
+| (none) | _default_ | — |
+| `filter:rank:gte:50` | `rank_filtered` | `50` |
+| `filter:rank:gt:50` | `rank_filtered` | `50 + ε` |
+| `sort:rank:desc` (± filter) | `rank_desc` | filter value or — |
+| `sort:rank:asc` (± filter) | `rank_asc` | filter value or — |
+
+`_apply_filters_and_sort`, `EXTENSION_OVERFETCH`, and `fetch_hits` are removed —
+results are emitted in the order Vespa returns them.
+
+> **`sort:rank:asc` + zero scores.** The default search drops `user_score ≤ 0`
+> hits. For ascending sort that would hide the lowest-trust docs the user
+> explicitly asked to see first, so the relay passes
+> `include_zero_score_results=True` only for `sort:rank:asc`.
+
+### Limitation — only `gte` / `gt` are supported natively
+
+`rank-score-drop-limit` is a **lower-bound** mechanism (a `≥` gate), so only
+`gte` and `gt` map to it. `gt:N` is implemented as `min_rank = N + ε` (and since
+`rank` is an integer 0–100, this is just `≥ N+1`).
+
+`lte` / `lt` / `eq` are **intentionally unsupported** and the relay returns a
+NIP-01 `NOTICE` when a client sends them. Supporting them natively would require
+re-modeling per-observer scores as a stored, range-queryable structure
+(e.g. `array<struct{observer, score}>` with `sameElement`, queryable in YQL
+`where`) — a new schema field + a dual write path alongside the ranking tensor +
+a **full re-feed**. Not worth it until there is real demand and more than one
+per-observer metric.
+
+---
+
+## Deploying schema changes
+
+Both `doc.sd` edits above are **rank-config only** — they do not touch the
+`document doc { … }` field block. That means:
+
+- **Redeploy reloads the rank config; no re-feed / reindex is needed.** Existing
+  docs and the `quality_scores` tensor are untouched.
+- Deploy by applying the Helm chart in `nosfabrica-kube` (the post-upgrade Job
+  re-POSTs the app package). Manual recipe: `charts/brainstorm/VESPA.md`.
+
+A change that *would* force a re-feed: adding/altering a field inside
+`document doc { … }` (e.g. the `array<struct>` re-model mentioned above).
+
+### One thing to verify live
+
+The docs don't pin down whether `rank-score-drop-limit` drops on `<` or `<=`.
+The sentinel gap makes it moot for real hits, but if you want certainty: run a
+query with `min_rank` set high against a known low-score doc and confirm it's
+absent.

--- a/docs/search-trust-vs-exact-match.md
+++ b/docs/search-trust-vs-exact-match.md
@@ -1,0 +1,180 @@
+# Search ranking: trust swamps exact matches
+
+_Last updated: 2026-06-28. Owner: search. Audience: the team — read this before
+touching the `name_and_quality_score_only` rank profile in `doc.sd`._
+
+This note is a follow-on to `search-precision-and-filtering.md`. That doc fixed
+**text-vs-text** ordering (trigram/fuzzy recall outranking exact token matches).
+This one is about the next layer up: **text-vs-trust** — the per-observer
+quality score (`quality_boost`) is so much larger than any text signal that it
+swamps it entirely, so genuine name matches from low-trust accounts fall off the
+end of the result set.
+
+> **Where the schema lives.** The *deployed* schema is
+> `nosfabrica-kube/charts/brainstorm/vespa-app/schemas/doc.sd`, shipped via the
+> Helm ConfigMap + post-install/upgrade Job (see `charts/brainstorm/VESPA.md`).
+> The copy under `brainstorm_one_click_deployment/vespa-app/` is **stale** —
+> treat the kube repo as source of truth.
+
+---
+
+## Symptom
+
+A test account **"Handled"** (`npub1m2lrsze…`, hex `dabe380b…`) does not appear
+in search results for the exact query `handled`, even though its `name` and
+`display_name` are exactly "Handled". The account is real, indexed, and has a
+(low) trust score. "It should be far down, but it should be *there*" — it isn't.
+
+## Investigation (staging, 2026-06-28)
+
+Three candidate causes, checked in order against staging Vespa
+(`kubectl exec -n staging brainstorm-vespa-0 -- curl localhost:8080/...`):
+
+1. **Filtered out by `onlyRanked`?** No. `/search/byText` defaults
+   `onlyRanked=true`, which drops any hit whose `user_score ≤ 0` for the search
+   observer. The doc's `quality_scores` tensor **has a cell for the default
+   observer** (`be7bf5de…`) with value `11` → `user_score = 11 > 0` → it passes
+   the filter.
+
+2. **Recall miss (not matched by the YQL)?** No. It's an exact token match on
+   both `name` and `display_name`.
+
+3. **Buried by ranking?** **Yes.** Direct Vespa rank breakdown for the doc under
+   the default observer, profile `name_and_quality_score_only`, query `handled`:
+
+   ```
+   relevance:          165.9
+     name_text:        110.5   ← exact token match (matchCount 1 ×100 + bm25)
+     display_name_text:111.1   ← primary_text = max(name, display_name)
+     about_text:         0.0
+     quality_boost:     54.8   ← from score 11
+     user_score:        11.0
+   ```
+
+   For comparison, the live `handled` result set (`maxHits=400`):
+
+   | Rank | Account         | relevance | quality score |
+   |------|-----------------|-----------|---------------|
+   | 1    | greencandleit   | 1053      | 94            |
+   | 2    | gandlaf21       | 1043      | 97            |
+   | 3    | kenn3d          | 1030      | 98            |
+   | …    | …               | …         | …             |
+   | 400  | ninjagrandma    | 895       | —             |
+   | ~?   | **Handled**     | **166**   | **11**        |
+
+   **None of the top results are the word "handled."** They are trigram-only
+   matches (`han` / `and` / `led` are common substrings — Alex**and**er,
+   g**and**laf, green**c**andleit…) riding on a near-maximal `quality_boost`.
+   Handled, at relevance 166, sits *hundreds* of places below the 400-hit
+   window, so the client never sees it.
+
+## Root cause
+
+The ranking blend is **additive**, and the two terms are on wildly different
+scales (`doc.sd`, profile `name_and_quality_score_only`):
+
+```
+relevance() = primary_text()  +  secondary_active()*w_about*about_text()  +  quality_boost()
+              └─── 0 … ~200 ───┘                                            └─── 0 … 1000 ───┘
+```
+
+- `primary_text()` for an **exact single-word** name match ≈ **110**
+  (`matchCount ×100` + small bm25). The per-field trigram contribution is capped
+  at `gram_cap = 80`.
+- `quality_boost()` is a logistic sigmoid of the observer's score, ranging
+  **0 … 1000** (σ centered at score 50).
+
+So the entire text signal (exact vs. trigram-only ≈ 110 vs. 80, a 30-point
+spread) is dwarfed by the ~1000-point trust term. Ranking is effectively
+"**sort by trust; text barely matters.**" The recall net is also broad — the
+trigram OR pulls in every high-trust account that shares *any* 3-char substring
+with the query — and additive trust then floats all of them above the real
+match.
+
+> The `gram_cap (80) < matchCount (100)` invariant noted in
+> `search-precision-and-filtering.md` only holds **at equal trust**. It says
+> nothing about the additive `quality_boost`, which is ~10× larger than the
+> whole text score and is what actually dominates here.
+
+## What we actually want
+
+Agreed product behavior (do **not** confuse with "exact match must be #1"):
+
+- **Trust/rank leads at the top.** Among genuine matches, the highest-trust
+  account ranks first. We want trust to drive the top of the list.
+- **A genuine name match must outrank a trigram-only accident.** "handled"
+  results should be accounts actually named/about "handled," not every
+  high-trust account that happens to contain `and`.
+- **Low-trust exact matches still appear** — below high-trust exact matches, but
+  above the trigram-only noise.
+
+Restated as a ranking rule:
+
+> **Match quality is the primary partition; trust orders within each partition.**
+> Exact/strong text match → top tier (ordered by trust). Trigram-only → lower
+> tier (ordered by trust). Trust must not let a lower tier jump a higher one.
+
+## Options
+
+### Why plain two-phase is *not* enough
+
+A first-phase=`primary_text()`, second-phase=`relevance()` split was the first
+idea. It fails: second-phase still uses the additive, trust-dominated
+`relevance()`, so once the trigram-only high-trust accounts survive into the
+re-rank set they re-bury the exact match exactly as before. Two-phase changes
+*which* docs get re-ranked, not the *formula* that orders them. The formula is
+the problem.
+
+### Option A — Tiered/gated additive (recommended)
+
+Gate on a real token match (which trigram-only matches do **not** have —
+`matchCount` counts `name`/`display_name` index hits, not `*_gram` hits) and add
+a constant large enough to clear the `quality_boost` ceiling:
+
+```
+has_token_match = if(matchCount(name) > 0 || matchCount(display_name) > 0, 1, 0)
+relevance() = has_token_match * TIER + primary_text() + secondary*about + quality_boost()
+```
+
+With `TIER = 1100` (just above the 1000 `quality_boost` max):
+
+| Doc                         | tier  | text | quality | total |
+|-----------------------------|-------|------|---------|-------|
+| High-trust exact match (100)| 1100  | 111  | ~1000   | ~2211 |
+| **Handled** (exact, 11)     | 1100  | 111  | 55      | ~1266 |
+| greencandleit (gram, 94)    | 0     | 80   | ~970    | ~1050 |
+
+Result: all genuine matches sit above all trigram-only matches; **within** each
+tier `quality_boost` still orders (trust leads at the top). Handled appears,
+below high-trust exact matches, above the noise. Minimal, well-understood
+change; preserves the existing trust-ranking behavior wholesale.
+
+_Open sub-question:_ fuzzy/prefix matches also increment `matchCount`, so they
+land in the same top tier as exact. That's probably fine (and is the
+`prefixLength:2`, `maxEditDistance:1` budget from Problem 1), but if we want
+exact strictly above fuzzy we add a second, smaller tier constant.
+
+### Option B — Multiplicative blend
+
+Make text a gate by multiplying instead of adding (cf. the unused `search_rank`
+profile): `relevance = text_score * (1 + k·user_score)`. Conceptually clean —
+zero/low text can't float on trust — but the raw text spread (exact 110 vs
+trigram 80) is too small to separate cleanly *because trigram matches still
+produce non-trivial text*, so it needs the same token-match gate as Option A to
+work well. More re-tuning, more global behavior change. Lower confidence.
+
+### Option C — Shrink `quality_boost` to a tie-breaker
+
+Cap `quality_boost` at, say, 80 so text leads. One-liner, but it throws away
+trust-led ranking at the top — directly contradicts "trust leads at the top."
+Rejected.
+
+## Recommendation
+
+**Option A.** It satisfies all three product requirements with the smallest,
+most legible change, and keeps trust as the ordering signal exactly where we
+want it. Validation plan: add the `has_token_match` tier to
+`name_and_quality_score_only` in `doc.sd`, redeploy to staging via the
+app-package hook, and re-run the `handled` query — expect Handled to surface
+below the high-trust exact matches and above the trigram noise. Add `matchCount`
+to `match-features` during validation so we can see the tier per hit.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -98,7 +98,7 @@ still mixing the two signals on one axis.
 | Exact-match priority | `exactness` ranking rule (structural) | `has_token_match()*1100` tier (manual) |
 | Field priority | `searchableAttributes` order (name>…>about) | `primary_text = max(name,display_name)`, about gated |
 | Searchable fields | name, display_name, username, **nip05, npub**, about, **lud16, website** | name, display_name, about (+ `*_gram`) |
-| Typo tolerance | Length-gated: ≥3→1 typo, ≥6→2 | Fuzzy `maxEditDistance:1, prefixLength:2` + **trigram OR firehose** |
+| Typo tolerance (deep-dive: §10) | Length-gated: ≥3→1 typo, ≥6→2 | Fuzzy `maxEditDistance:1, prefixLength:2` + **trigram OR firehose** |
 | Prefix / search-as-you-type | On by default | `prefix:true` userInput clause |
 | Proximity (multi-word) | `proximity` ranking rule | None (per-word OR groups + CamelCase-join variant) |
 | NIP-05 verification | Parallel `.well-known/nostr.json` lookup + surface verified hit | None |
@@ -487,3 +487,149 @@ stage, avoid on a large one):
 POD=$(kubectl -n "$NS" get pod -l app.kubernetes.io/component=brainstorm-server -o jsonpath='{.items[0].metadata.name}')
 kubectl -n "$NS" exec "$POD" -- sh -c 'cd /app && poetry run python -m scripts.refeed_kind0_to_vespa --status'
 ```
+
+---
+
+## 10. Typo handling: Vespa vs Meilisearch (deep-dive)
+
+_Added 2026-06-30. Reference for team questions on why our results differ from
+Meilisearch on misspelled / partial queries. Mechanics confirmed against
+Meilisearch's docs (typo-tolerance internals + ranking rules)._
+
+### 10.1 What typo compensation we have (Vespa)
+
+Three mechanisms, OR'd per query word in `app/core/vespa.py`:
+
+| Mechanism | Config | Catches |
+|---|---|---|
+| Fuzzy (Levenshtein) | `maxEditDistance:1, prefixLength:2`, words **≥4 chars** (`_word_max_edits`) | 1 edit in char ≥3 (`nosfabrcia`→`nosfabrica`) |
+| Prefix | `prefix:true` userInput, on **every** word (`_field_clauses`) | partial / search-as-you-type (`nosfab`→`nosfabrica`) |
+| Trigram n-grams | `name_gram`/`display_name_gram` (OR of 3-grams), `about_gram` (AND) | infix/substring + fuzzy-ish recall (`fabrica`→`nosfabrica`) |
+
+Plus whole-string CamelCase concat (`@wj`) and Vespa linguistics (lowercase +
+accent-fold). Key properties:
+
+- `prefixLength:2` hard-blocks any typo in the **first two characters**.
+- Fuzzy budget is **flat: ≥4 chars → 1 edit, never 2**.
+- Vespa fuzzy is **plain Levenshtein** → a transposition (`Alcie`→`Alice`) is 2
+  edits and won't match at budget 1. *(Verify — not Damerau by default.)*
+- `matchCount()` scores exact, prefix, and fuzzy hits **identically** — we have
+  no exact>typo tier (only `has_token_match` separates token hits from
+  trigram-only noise).
+
+### 10.2 What Meilisearch does
+
+- **FST + Damerau-Levenshtein automaton** (no n-grams). Damerau → a transposition
+  is **1 edit** (`teh`→`the`).
+- **Length-gated budget** (defaults): 1–4 → 0 (prefix only); 5–8 → 1; 9+ → 2;
+  hard cap 2. *(Tapestry overrode to `oneTypo:3, twoTypos:6`.)*
+- **First-char typo costs 2** (so only correctable on 9+ char words; stops
+  `caturday`→`saturday`).
+- **Prefix + typo unified, on the LAST word only** (search-as-you-type).
+- **Word split & concat as typos** (`any way`↔`anyway`; `newspaper`→`news`+`paper`,
+  frequency-chosen), each costing 1 typo.
+- **`typo` is a ranking BUCKET** in `words→typo→proximity→attribute→sort→exactness`:
+  0-typo > 1-typo > 2-typo, deterministically, and above `attribute`. No score
+  blending.
+
+### 10.3 Differences that cause mismatches (ranked)
+
+1. **Exact-vs-typo ordering** — Meili buckets exact above any typo/prefix; we
+   flatten all into `matchCount`, so a fuzzy/prefix hit can tie/outrank an exact
+   name. (= the deferred "Option B" in `search-precision-and-filtering.md`.)
+2. **Transpositions** — Meili (Damerau) catches at cost 1; we (Levenshtein) need
+   2 → missed at our budget of 1 (trigrams only partly cover it).
+3. **Budget by length** — ours flat ≥4→1; Meili 5→1 / 9→2. We're looser on
+   4-char words (noise) but miss double-typos on 9+ names.
+4. **First/second-char typos** — our `prefixLength:2` blocks them; Meili corrects
+   a char-2 typo on a 5+ word.
+5. **Word boundaries** — Meili splits/concats both directions; we only do one
+   whole-string `@wj` concat.
+6. **Proximity** — Meili rewards multi-word closeness; we have none.
+7. **Trigram firehose** — our any-shared-3-gram recall (capped in ranking but
+   widens the candidate set); Meili has nothing like it.
+8. **Stemming** — we default `stemming: best` on names (conflates proper nouns,
+   `Daniels`→`daniel`); Meili doesn't.
+
+### 10.4 Tuning options + deploy impact
+
+**No new data (no kind-0 re-feed / no GrapeRank re-sync) is needed for any of
+these.** Only #3 touches the index; everything else is rank-config and/or server
+query-code (online).
+
+| # | Change | Where | Deploy impact |
+|---|---|---|---|
+| 1 | Exactness ladder (query `{label}` + `itemRawScore` tiers: exact>prefix>fuzzy) | `_word_group`/`_field_clauses` + doc.sd rank profile | **rank-config + server code** — online redeploy, **no reindex, no data** |
+| 2 | Length-gated 2-typo (≥9), once #1 is in | `_word_max_edits` | **server code only** — no reindex, no data |
+| 3 | `stemming: none` on `name`/`display_name`/`username` | doc.sd `document doc {}` | **index change → reindex from doc store** (text already stored, **no re-feed / no new data**); likely needs a `validation-overrides.xml` `indexing-change` allow (cf. §9.1) |
+| 4 | Proximity (`fieldMatch`/`nativeProximity`) | doc.sd rank profile | **rank-config only** — uses the existing positional index, no reindex/data |
+| 5 | Damerau/transposition (if Vespa fuzzy supports it) | query annotation in `_field_clauses` | **server code only** — no reindex/data |
+| 6 | Per-adjacent-pair concat / splitting | `_build_yql` | **server code only** — no reindex/data |
+
+> **Confirm against live data only after the kind-0 backfill completes** (§9.6) —
+> until then "Meili found X, we didn't" may be un-indexed docs, not a typo gap.
+> And our trigram net is a real capability Meili lacks (true infix/substring); the
+> aim is to demote it under a proper exactness tier, not delete it.
+
+### 10.5 Status (implemented 2026-06-30) + staging validation
+
+Implemented: **#1** exactness ladder, **#2** length-gated 2-typo, **#3** stemming,
+**#4** proximity, **#6** adjacent-pair concat.
+
+- **#5 (Damerau/transpositions) is NOT implementable** — Vespa fuzzy is plain
+  Levenshtein with no transposition option. The trigram net is our only cover.
+- **#6 word *splitting* deferred** — Meili splits by index term-frequency; we
+  have no cheap frequency source, so we ship concatenation only.
+
+Where:
+- `app/core/vespa.py` — `_field_clauses` labels exact/prefix/`fz1`/`fz2` on the
+  primary fields (name/display_name/username/nip05); `_word_max_edits` gate
+  (<4→0, ≥4→1, ≥9→2); `_build_yql`/`search` add adjacent-pair concats (`@wp{i}`);
+  `search()` surfaces `_match_quality`/`_match_tier` per hit.
+- `doc.sd` `text_relevance` — `match_quality()` (itemRawScore ladder) +
+  `proximity()` (fieldMatch) folded into `relevance()`; `stemming: none` on
+  name/display_name/username; itemRawScores + `match_quality` in match-features.
+- `doc.sd` **popularity/trust profiles** (`sort_followers` default, `rank_desc`,
+  `rank_asc`) — the match tier now sits ABOVE the follower/trust sort via two
+  inputs: `query(w_pop_token_tier)` (token vs gram, always on — also fixes the
+  old `*1100`-too-small-vs-followers weakness) and `query(w_pop_match_step)`
+  (exact>prefix>1-typo>2-typo above followers; **set 0 to revert to pure
+  popularity-within-token**). So the DEFAULT search keeps "popular accounts on
+  top" but a genuine name match never loses to a more-popular typo/substring hit
+  (Meili's `typo`-over-`sort`). `scripts/search_http.sh` prints `tier=`/`flw=`
+  per hit so you can see this.
+
+**The ladder is additive on `has_token_match`** — if `itemRawScore` is not
+populated for plain text terms, `match_quality()` is 0 everywhere and ordering
+falls back to today's behavior (no regression). So the staging deploy MUST confirm
+itemRawScore fires before #2 (wider fuzzy) is worth anything.
+
+Easiest check — `/search/byText` now surfaces the tier per hit (`_match_quality`
+0–4 + `_match_tier` "exact"/"prefix"/"1-typo"/"2-typo"/"gram"), so after deploying
+**both** the schema and the server:
+
+```bash
+curl -s "https://<stage-api>/search/byText?text=<exact-name>&maxHits=5" \
+  | grep -o '"_match_tier":"[^"]*"'
+```
+
+An exact-name query should report `"_match_tier":"exact"` on the matching hit. If
+every hit is `"gram"`, `itemRawScore` isn't firing for text terms. Raw-Vespa
+equivalent (URL-encode the YQL):
+
+```bash
+# exact "jack" against a labeled name clause — expect itemRawScore(mtch_exact) > 0
+kubectl -n <ns> exec brainstorm-vespa-0 -- curl -s \
+  'http://localhost:8080/search/?ranking=text_relevance&hits=1&q=jack&yql=' \
+  'select * from doc where ({label:"mtch_exact",defaultIndex:"name"}userInput(@q))' \
+  | grep -o '"itemRawScore(mtch_exact)":[0-9.]*'
+```
+
+If that is `0` on a known exact match, the ladder isn't firing — pivot the
+exact-detection mechanism (e.g. a dedicated exact-only field, or `rank()` with a
+separately-scored clause) before trusting the tiers.
+
+**Deploy ordering:** everything is rank-config / server-code EXCEPT `stemming:
+none`, which forces a reindex + a `validation-overrides.xml` `indexing-change`
+allow (§9.1). Sequence the stemming deploy **after** the in-flight kind-0 backfill
+so the reindex doesn't contend with the re-feed.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -633,3 +633,46 @@ separately-scored clause) before trusting the tiers.
 none`, which forces a reindex + a `validation-overrides.xml` `indexing-change`
 allow (§9.1). Sequence the stemming deploy **after** the in-flight kind-0 backfill
 so the reindex doesn't contend with the re-feed.
+
+---
+
+## 11. About-affiliation tier (2026-06-30)
+
+**Motivation** (found live on `odell`): impersonators and trigram collisions
+(accounts sharing `ell`/`del`/`ode`) outranked genuinely-related accounts.
+**Citadel Dispatch** — Odell's show, bio "hosted by ODELL" — sat at rank ~14: it
+matches `odell` only in `about`, and `about` matches earn no ranking tier
+(`has_token_match` excludes `about`), so it was ordered purely by follower count
+beneath higher-follower noise.
+
+**Fix** — a middle tier between name matches and gram noise:
+
+```
+name match (exact > prefix > 1-typo > 2-typo)   ← has_token_match + match_quality
+about affiliation (genuine bio token match)      ← about_match   (NEW)
+gram / recall noise                              ← neither
+```
+
+- **Query** (`_field_clauses`): the `about` **exact** clause is labeled
+  `mtch_about`; prefix/fuzzy on `about` stay unlabeled (pure recall, no tier).
+- **Rank** (`about_match()` = `itemRawScore(mtch_about) > 0`) adds a band:
+  - popularity/trust profiles: `about_match() * query(w_about_tier)` (1e7 — above
+    followers, below the 1e9 name band).
+  - text profile: `about_match() * query(w_about_tier_text)` (400 — below the
+    1100 name band, above gram/primary_text).
+- Within every band the existing sort applies (verified followers on the
+  default), so: **real ODELL on top (name+followers), related accounts like
+  Citadel Dispatch next (about+followers), coincidental substring hits last.**
+
+**Tunable / safe:**
+- `w_about_tier` / `w_about_tier_text` = 0 disables the tier (pure name > gram).
+- `about_match()` is itemRawScore-driven → degrades to 0 (gram behavior) if
+  itemRawScore isn't populated; same safety net as `match_quality` (§10.5).
+- `_match_tier` (API + `search_http.sh`) now reports `about` for these hits, so
+  the tier is visible per result.
+
+**Scope:** only the bio (`about`) feeds this tier; `lud16`/`website` stay pure
+recall. Extend `_field_role` in `app/core/vespa.py` if payment/website
+affiliation should also count. Note impersonators *named* the query stay in the
+name tier — verified-follower ordering within that tier (once ingest completes)
+is what sinks them beneath the real account.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -671,8 +671,38 @@ gram / recall noise                              ← neither
 - `_match_tier` (API + `search_http.sh`) now reports `about` for these hits, so
   the tier is visible per result.
 
-**Scope:** only the bio (`about`) feeds this tier; `lud16`/`website` stay pure
-recall. Extend `_field_role` in `app/core/vespa.py` if payment/website
-affiliation should also count. Note impersonators *named* the query stay in the
-name tier — verified-follower ordering within that tier (once ingest completes)
-is what sinks them beneath the real account.
+**Scope:** the bio (`about`) and the account's own `website` domain feed this
+tier; `lud16` stays pure recall. Extend `_field_role` in `app/core/vespa.py` if
+lud16 affiliation should also count. Note impersonators *named* the query stay in
+the name tier — verified-follower ordering within that tier (once ingest
+completes) is what sinks them beneath the real account.
+
+### 11.1 itemRawScore doesn't work for text terms — the exactness ladder is deferred
+
+**Confirmed on staging (2026-06-30):** after deploy, `itemRawScore(mtch_exact)`
+and `itemRawScore(mtch_affil)` are **`0.0` even on an exact "ODELL" name match**.
+Vespa only populates `itemRawScore` for operators that compute a raw score
+(`dotProduct`/`wand`/`weightedSet`/`nearestNeighbor`) — **not** plain indexed
+`userInput` text terms. So the entire label-based design (§10 `match_quality`,
+the exact>prefix>1-typo>2-typo ladder) is **inert** — `match_quality()` is always
+0. The safe-degrade held (nothing broke: `has_token_match` via `matchCount` still
+tiers name matches above noise), but the fine ladder never activated.
+
+**What we changed in response:**
+- `affiliation_match()` repointed to **`matchCount(about) || matchCount(website)`**
+  (gated on `!has_token_match`) — `matchCount` is reliable, so the affiliation
+  tier now actually fires (CITADEL DISPATCH → tier `affiliation`).
+- `_match_tier` now reports **`name` > `affiliation` > `gram`** (from
+  `has_token_match` / `affiliation_match` / neither). The `exact/prefix/1-typo/
+  2-typo` labels are retained only for if/when the ladder is revived.
+- The `mtch_*` query labels + `match_quality()` are left in place but **inert**
+  (0 contribution) as scaffolding.
+
+**To revive the fine name ladder (exact > prefix > typo)** — the only reliable
+Vespa mechanism for plain text is to make the match types land in **separate
+matchable fields** so `matchCount` can tell them apart, e.g. a verbatim
+`name_exact` field (`match: word`, no fuzzy) that the exact clause targets, then
+`matchCount(name_exact)` = exact-only. That's a **new field + reindex**, so it's
+deferred. In practice the coarse `name`-tier + **verified-follower ordering**
+already floats the real account above impersonators once ingest completes, so the
+fine ladder is a refinement, not a blocker.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -272,6 +272,34 @@ so indexing it only adds marginal partial-match value.
 - `username` is not in Vespa at all → ingest change (extract from kind-0
   content) **+ a kind-0 re-feed** from strfry.
 
+#### 8.4.1 kind-0 ingest robustness — read BOTH content and tags
+
+We currently ingest kind-0 at `process_strfry_event.py:process_event_kind_0`,
+which parses **only `event["content"]` (the JSON-encoded field) and ignores
+`event["tags"]`**. Newer clients mirror the same profile fields as tags
+(`["name", …]`, `["display_name", …]`, `["nip05", …]`, …) — sometimes *in
+addition to* content, sometimes as the primary source.
+
+Two concrete bugs this creates:
+
+1. **Wipe risk (correctness, not just recall).** `upsert_profile` is a *replace*
+   that assigns `""` to any `PROFILE_FIELDS` key missing from the new event. A
+   tag-only kind-0 with empty/minimal `content` parses to `{}` and would
+   **blank out** that profile's searchable fields in Vespa instead of being
+   ignored.
+2. **camelCase variants dropped.** Clients send `displayName` (camelCase) and
+   `username`; we only read `display_name` and don't read `username` at all.
+
+Fix (build with P1, not a JSON-only `username` add):
+- Merge sources: build the profile dict from `content` JSON **and** from the
+  `[key, value]` profile tags, with a precedence rule (content wins; tags fill
+  gaps).
+- Normalize aliases: `displayName` → `display_name`, etc.
+- **Don't-clear guard:** never overwrite an existing non-empty field with `""`
+  from a *less-complete* event, so a sparse tag-only update can't wipe a good
+  profile.
+- Then extract the expanded `PROFILE_FIELDS` (now including `username`).
+
 ### 8.5 Backfill / deploy — one maintenance window
 
 These are independent datasets but batch into one window:

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -328,3 +328,87 @@ running Vespa must already have.
    add `followers` metric to the NIP-50 `sort:`/`filter:` map.
 4. P1 ingest: extract `username`; add the new searchable fields to the YQL groups.
 5. Tests + A/B on staging with `scripts/search_*.sh`; then the §8.5 backfill.
+
+---
+
+## 9. Deploy runbook
+
+**Status: the code (server + tests) is committed; the schema (`doc.sd`) is
+edited but uncommitted in nosfabrica-kube. Nothing is live yet.**
+
+### 9.0 What each change does to Vespa (and whether it needs a backfill)
+
+| Schema change | Vespa behavior | Populated by |
+|---|---|---|
+| New rank profiles (`sort_followers`, edited `rank_*`) | online, instant; no data impact | — |
+| Extended `has_token_match` (matchCount username/nip05) | online (rank expr) | — |
+| New attribute `follower_counts` (tensor) | online; **empty** for existing docs | **score re-sync** (GrapeRank) |
+| New field `username` (indexed) | online; **empty** for existing docs | **kind-0 re-feed** (source data not in Vespa) |
+| `nip05`/`lud16`/`website` `summary` → `index\|summary` | indexing change; index **empty** for existing docs until rewritten | **kind-0 re-feed** (rewrites docs through the new pipeline) |
+
+No change here drops data or requires a full reindex-from-scratch. **No
+downtime** at any step — schema changes are online and backfills are background.
+
+### 9.1 Known unknowns to settle ON STAGING FIRST
+
+1. **Does `prepareandactivate` accept the `summary→index` change?** There is no
+   `validation-overrides.xml` in the app package, so if Vespa classifies this as
+   a change needing an override, the post-upgrade Job **fails loudly** (non-zero,
+   visible in `kubectl logs job/<release>-brainstorm-vespa-app-<rev>`). Fix:
+   add `vespa-app/validation-overrides.xml` allowing the flagged change, or split
+   the index-field change into its own later deploy.
+2. **There is no kind-0 re-feed tool.** `nostr_event_transferer` only re-syncs
+   kinds 3/10000/1984 — **not kind 0**. Populating `username` (and rewriting the
+   nip05/lud16/website indexes) needs a NEW small script: read kind-0 from the
+   internal strfry and call `vespa.upsert_profile` for each. Until that runs,
+   those fields stay empty for existing profiles (new/updated profiles fill in
+   organically as their kind-0 flows through `process_strfry_event`).
+
+### 9.2 Sequence (run on staging, verify, then repeat on prod off-peak)
+
+1. **Pre-flight:** confirm a recent `brainstorm-backups-vespa` CronJob run; confirm
+   `vespa.appPackage.enabled=true`.
+2. **Deploy schema + server together** (`helm upgrade`, per `charts/brainstorm/VESPA.md`).
+   The post-upgrade hook zips `vespa-app/` and POSTs it to
+   `:19071/.../prepareandactivate`. **Watch the Job log** (§9.1 item 1).
+   - *Impact now:* byText/NIP-50 immediately use `sort_followers`, but
+     `follower_counts` is empty → all same-tier hits tie at 0 followers → ordering
+     within a tier is flat until step 3. The `rank≥2` filter works immediately
+     (it reads the existing `quality_scores`). General name/display/about search
+     is unaffected. **Brief window:** if the server pod is ready before the
+     app-package Job activates, byText returns errors ("unknown rank profile
+     sort_followers") for a few seconds — re-run is harmless; the Job retries
+     config-server readiness.
+3. **Score re-sync** (populates `follower_counts` + applies `>0` ingest):
+   trigger GrapeRank for the default observer — admin
+   `POST /admin/brainstormPubkey/{pubkey}/trigger_graperank`, or wait for
+   `periodic_graperank_trigger`. `VESPA_FULL_SYNC=True` (already set) pushes every
+   rank>0 scorecard with its `trusted_followers`.
+   - *Impact:* a large bounded (`_BATCH_CONCURRENCY=32`) burst of partial-update
+     writes to Vespa; more rows than before (>0 vs ≥0.05). Search stays up; minor
+     latency bump under heavy feed. After it completes, follower-sort is live.
+4. **kind-0 re-feed** (populates `username`; rewrites nip05/lud16/website indexes)
+   — run the new re-feed script (§9.1 item 2). Bounded throughput; online.
+   - *Impact:* one partial-update per profile. `quality_scores`/`follower_counts`
+     tensors are preserved (partial update doesn't touch them). The skip-empty +
+     content/tags merge means no profile gets wiped.
+5. **Verify** with `scripts/search_http.sh` / `search_compare.sh` / `search_nip50.sh`:
+   popular-first ordering, `rank≥2` exclusion, `username`/`nip05` matches, and
+   `sort=rank` / `sort=text` alternates.
+
+### 9.3 Rollback
+
+`helm rollback` (or redeploy the prior chart) reverts the rank profiles and the
+server. The added `follower_counts`/`username` fields and any written cells are
+**harmless to leave** — the previous profiles simply don't read them, and no data
+is lost. The `summary→index` change is the only one that isn't a clean auto-revert
+(removing an index may need an override); prefer rolling *forward* (fix + redeploy)
+over rolling back that specific field.
+
+### 9.4 Degraded-but-functional windows (summary)
+
+| Between… | Search still works? | What's missing |
+|---|---|---|
+| schema deploy → score re-sync | yes | follower ordering is flat (ties at 0) |
+| schema deploy → kind-0 re-feed | yes | username / nip05 / lud16 / website matches on existing profiles |
+| server ready → app-package active | ~no (seconds) | byText errors on unknown profile until the Job activates |

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -707,3 +707,60 @@ matchable fields** so `matchCount` can tell them apart, e.g. a verbatim
 deferred. In practice the coarse `name`-tier + **verified-follower ordering**
 already floats the real account above impersonators once ingest completes, so the
 fine ladder is a refinement, not a blocker.
+
+---
+
+## 12. Default rewrite: IDF-diluted text × multiplicative trust (2026-07-01)
+
+Team feedback raised two distinct problems with the default (`sort_followers`):
+
+1. **Common tokens flood.** `primal` returned *everyone* with a `primal.net`
+   `nip05`, because `nip05`/`lud16` matches fed the flat `has_token_match` tier
+   (a binary count) — completely IDF-blind, so a token in thousands of docs got
+   the same boost as a unique one. But a `nip05` that *is* the person's handle
+   (`vitorpamplona.com`) should surface.
+2. **Trust was added, not multiplied.** The additive tier + follower model (and
+   the earlier `quality_boost`) let trust *swamp* text. The team asked to
+   **multiply** text by a rank function instead — with a cutoff and a modest,
+   concave curve.
+
+### 12.1 IDF (the "primal" fix)
+
+**IDF = inverse document frequency** — rare words score high, common words low
+(`≈ log(total_docs / docs_with_word)`). `bm25()` is `tf × IDF` built in, and
+`about` already used it. The fix: give `nip05`/`lud16` the same treatment.
+
+- `identity_text() = bm25(nip05) + bm25(lud16)` — `primal`/`gmail`/`com` → ~0
+  (common), `vitorpamplona` → high (unique).
+- `name_match()` = name/display_name/username **only** (nip05/lud16 removed from
+  the name tier — they now score via `identity_text`).
+- New tier order: **name > identity > affiliation > gram**.
+
+### 12.2 Multiplicative trust (NOT additive)
+
+```
+first-phase = text_score() * wot_mult()          # MULTIPLY, never +
+wot_mult()  = if(rank < cutoff, 0, 1 + w_wot * log(1 + rank - cutoff))
+```
+- `rank` = `user_score()` (observer influence×100). `cutoff` = `query(min_rank)`
+  (server passes 2) — the old hard step becomes "0 below, concave-increasing above".
+- Multiplying means text relevance is always the driver — zero text × any trust
+  is still zero, so trust can't manufacture relevance (avoids the swamping in §
+  `search-trust-vs-exact-match.md`).
+- `log` = **modest, diminishing-returns** boost (~1× to ~5.6× across rank 2–100
+  at `w_wot=1`), vs raw `rank` which would be a 50× swing.
+
+### 12.3 Scope, tuning, deploy
+
+- **Default only.** `sort_followers` is rewritten; `sort=text`/`sort=rank`
+  (`text_relevance`/`rank_desc`/`rank_asc`) are untouched. `verified_followers`
+  is kept only as a surfaced signal — it's **no longer the sort key** (supersedes
+  §8.1's popularity-first). Confirm that's the intended default.
+- **All rank-config** — `query()` inputs (`w_wot`, `w_identity`, `w_name_tier`,
+  `min_rank`) tune it **live, no redeploy**. Defaults are starting points; tune on
+  staging. The **inspector** exposes a `w_wot` knob + a `×wot` column + the
+  `identity` tier so you can watch it.
+- **Three places** move together: `doc.sd` (the ranking), `brainstorm_server`
+  (`vespa.py` tier/signal surfacing), and `search-inspector` (`app.py` mirror).
+  The query builder (`vespa_query.py`) does **not** change — nip05/lud16 are still
+  *matched*, only *scored* differently.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -448,3 +448,42 @@ lost. The `summary→index` change is the only one that isn't a clean auto-rever
 - Once the index is in steady state, consider flipping `VESPA_FULL_SYNC` to
   `False` (`upload_nostr_events.py`) so routine GrapeRank runs only push *changed*
   scores instead of the full set.
+
+### 9.6 kind-0 repopulation on an already-running namespace
+
+Pulls the new P1 fields (`username`, indexed `nip05`/`lud16`/`website`) into Vespa
+for existing docs via `scripts/refeed_kind0_to_vespa.py`. **Schema must already be
+deployed** (§9.2 step 2) or every upsert fails on an unknown field.
+
+Runs as the suspended `vespa-kind0-refeed` CronJob (chart:
+`templates/vespa-kind0-refeed.yaml`) in its own pod — own resources, durable
+logs, no load on the live API server. Trigger on demand and tail the logs
+(the script prints per-page progress):
+
+```bash
+export KUBECONFIG=~/.kube/configs/<stage>.conf   # e.g. arrowhead-admin.conf
+NS=<namespace>                                    # e.g. staging | arrowheadstaging
+
+kubectl -n "$NS" create job vespa-kind0-refeed-now \
+  --from=cronjob/brainstorm-vespa-kind0-refeed
+kubectl -n "$NS" logs -f job/vespa-kind0-refeed-now
+```
+
+Knobs: `vespaKind0Refeed.concurrency` / `.page` in values. Idempotent; a retry
+restarts from newest (the resume cursor is pod-local, lost on restart). Trust /
+follower-count backfill is separate (`trigger_graperank_all.py`, §9.2 step 4).
+
+Verify (expect ≥1 hit where there were none before):
+
+```bash
+kubectl -n "$NS" exec brainstorm-vespa-0 -- curl -s \
+  'http://localhost:8080/search/?yql=select%20pubkey%2Cusername%20from%20doc%20where%20username%20contains%20%22<username>%22&hits=5'
+```
+
+Quick one-off without the Job (runs inside the live server pod — fine for a small
+stage, avoid on a large one):
+
+```bash
+POD=$(kubectl -n "$NS" get pod -l app.kubernetes.io/component=brainstorm-server -o jsonpath='{.items[0].metadata.name}')
+kubectl -n "$NS" exec "$POD" -- sh -c 'cd /app && poetry run python -m scripts.refeed_kind0_to_vespa --status'
+```

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -194,3 +194,105 @@ NIP-50 relay** — matching tapestry exactly. This decides whether P0 means "dro
 | NIP-05 verify + dedup | `src/api/search/profiles/meili/index.js:26-46, 209-214` |
 | NIP-50 parse / execute | `nip50-proxy/src/search.js:25-62, 111-166` |
 | Design rationale | `nostr-search/BIBLE.md:201, 305-318`; `engineering-team/epics/search-quality.md` |
+
+---
+
+## 8. Agreed implementation plan (team decisions, 2026-06-29)
+
+We are proceeding with **P0 + P1**. The default behavior below **supersedes §6's
+"pure-text default for /search/byText"** — the team chose a popularity-first
+default ("first-time users expect popular accounts at the top").
+
+### 8.1 Default ranking — `text → filter rank≥2 → sort by verified followers`
+
+The SAME default for both `/search/byText` (UI) and the NIP-50 relay:
+
+1. **Text match** (existing recall + the `has_token_match` tier so genuine
+   matches beat trigram noise).
+2. **Filter `rank ≥ 2`** at query time via `query(min_rank)=2` (configurable
+   per query). `rank` = the observer's GrapeRank score (`influence×100`, 0..100),
+   i.e. the existing `quality_scores` tensor.
+3. **Sort by verified-follower count** (`trusted_followers`), descending.
+
+"Order by rank" was considered; verified-follower count was chosen as the
+default because it maps to "popular" more intuitively. **Sorting is
+configurable** via a `sort=` param (byText) / `sort:` token (NIP-50):
+
+| `sort=` | profile | sort key (filter is always `rank ≥ min_rank`) |
+|---|---|---|
+| `followers` (default) | `sort_followers` | `has_token_match*1100 + verified_followers()` |
+| `rank` | `rank_desc` | `has_token_match*1100 + user_score()` |
+| `text` | `text_relevance` (the P0 profile) | `relevance()` (pure text) |
+
+So **P0 isn't discarded** — `text_relevance` becomes the `sort=text` option, and
+P0's architecture (text & trust as separate dimensions, the match-quality tier)
+is what makes this clean. `DEFAULT_RANK_PROFILE` moves from `text_relevance` to
+`sort_followers`.
+
+### 8.2 New metric: verified-follower count in Vespa
+
+`scorecard.trusted_followers` is already computed and **already published in the
+kind-30382 TA events** (`upload_nostr_events.py:105`) — it's just never sent to
+Vespa. To sort on it:
+
+- **Schema:** add `field follower_counts type tensor<float>(user{})` (per-observer,
+  same shape as `quality_scores`). Must be `float`, not `int8` — counts exceed
+  int8's 127 ceiling; Vespa tensors only support int8/bfloat16/float/double.
+- **Pipeline:** `upsert_scores_to_vespa` pushes a second cell
+  (`trusted_followers`) alongside the existing rank cell.
+- **Rank profile:** `verified_followers() = sum(query(user_q) * attribute(follower_counts))`.
+
+### 8.3 Vespa ingest threshold — index scores **> 0** (not `== 0`)
+
+Decouple the **Vespa** ingest/removal threshold from the **Nostr TA publish**
+cutoff (`cutoff_of_valid_graperank_scores`, 0.05). The TA publish/delete cutoff
+stays as-is (0.05); Vespa indexes **everything with rank > 0** so it's all
+searchable, and the `rank ≥ 2` *default filter* (§8.1) decides visibility at
+query time.
+
+Implementation note — the cutoff currently drives THREE things
+(`upload_nostr_events.py`): TA publish (line 98), Vespa ingest (line 280), and
+the deletion set (lines 341-346) which feeds BOTH Nostr kind-5 deletes and Vespa
+`removes`. So ">0 ingest" requires:
+
+- **Ingest:** line 280 gate → `round(influence*100) <= 0: continue` (was `< cutoff`).
+- **Removal:** split the single `pubkeys_to_delete` set. Nostr deletes stay
+  cutoff-based; the **Vespa remove set must be rank==0 / gone-from-scorecards
+  only**, or rank 1-4 profiles get ingested then immediately swept out.
+
+### 8.4 P1 — more searchable fields
+
+Add searchable: `username`, `nip05`, `lud16`, `website`. **Skip `npub`** — the
+router already resolves npub/hex to a direct doc fetch (`_try_resolve_pubkey`),
+so indexing it only adds marginal partial-match value.
+
+- `nip05`, `lud16`, `website` are already stored (`indexing: summary`) → flip to
+  `index | summary` → **Vespa reindex** (rebuilds from the doc store, no strfry
+  re-feed).
+- `username` is not in Vespa at all → ingest change (extract from kind-0
+  content) **+ a kind-0 re-feed** from strfry.
+
+### 8.5 Backfill / deploy — one maintenance window
+
+These are independent datasets but batch into one window:
+
+| Work | Backfill | Mechanism |
+|---|---|---|
+| follower_counts tensor (§8.2) + >0 ingest (§8.3) | score re-sync | GrapeRank `VESPA_FULL_SYNC=True` |
+| P1: username (§8.4) | profile re-feed | replay kind-0 from strfry (also rebuilds nip05/lud16/website indexes) |
+| P1: nip05/lud16/website only (if skipping username) | reindex | Vespa `reindex` |
+
+Deploy schema (follower_counts + P1 index fields) **with** the server change
+together — `DEFAULT_RANK_PROFILE = "sort_followers"` references a profile the
+running Vespa must already have.
+
+### 8.6 Build order
+
+1. Schema: `follower_counts` tensor + `sort_followers` profile + P1 `index`
+   fields (doc.sd, nosfabrica-kube).
+2. Pipeline: push `trusted_followers`; change ingest/removal to >0 (split the
+   delete set).
+3. API: `DEFAULT_RANK_PROFILE = "sort_followers"`; add `sort=` to `/search/byText`;
+   add `followers` metric to the NIP-50 `sort:`/`filter:` map.
+4. P1 ingest: extract `username`; add the new searchable fields to the YQL groups.
+5. Tests + A/B on staging with `scripts/search_*.sh`; then the §8.5 backfill.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -306,17 +306,21 @@ Fix (build with P1, not a JSON-only `username` add):
 
 ### 8.5 Backfill / deploy — one maintenance window
 
-These are independent datasets but batch into one window:
+The schema + server deploy together; then two independent backfills (tooling now
+exists for both):
 
 | Work | Backfill | Mechanism |
 |---|---|---|
-| follower_counts tensor (§8.2) + >0 ingest (§8.3) | score re-sync | GrapeRank `VESPA_FULL_SYNC=True` |
-| P1: username (§8.4) | profile re-feed | replay kind-0 from strfry (also rebuilds nip05/lud16/website indexes) |
-| P1: nip05/lud16/website only (if skipping username) | reindex | Vespa `reindex` |
+| follower_counts tensor (§8.2) + >0 ingest (§8.3) | score re-sync | `scripts/trigger_graperank_all.py` (all observers, paced) — or just the default observer for anonymous search |
+| P1: username (§8.4) + the nip05/lud16/website indexes | profile re-feed | `scripts/refeed_kind0_to_vespa.py` (replays kind-0 through the live ingest path) |
 
-Deploy schema (follower_counts + P1 index fields) **with** the server change
-together — `DEFAULT_RANK_PROFILE = "sort_followers"` references a profile the
-running Vespa must already have.
+The `summary→index` change on nip05/lud16/website requires
+`vespa-app/validation-overrides.xml` (`indexing-change`) — see §9.1. Once the
+change is accepted, Vespa can also reindex those three from its doc store, but
+the kind-0 re-feed (run for `username` anyway) rebuilds them regardless.
+
+Deploy schema **with** the server — `DEFAULT_RANK_PROFILE = "sort_followers"`
+references a profile the running Vespa must already have.
 
 ### 8.6 Build order
 
@@ -333,82 +337,114 @@ running Vespa must already have.
 
 ## 9. Deploy runbook
 
-**Status: the code (server + tests) is committed; the schema (`doc.sd`) is
-edited but uncommitted in nosfabrica-kube. Nothing is live yet.**
+**Status (2026-06-30):** server code + tests committed; the two backfill scripts
+(`scripts/trigger_graperank_all.py`, `scripts/refeed_kind0_to_vespa.py`)
+committed. In nosfabrica-kube (uncommitted, deploy-time): `doc.sd` **and**
+`vespa-app/validation-overrides.xml`. Validated on an alternate staging that the
+`summary→index` change is rejected without the override (now added — §9.1). No
+downtime at any step; schema changes are online, backfills are background.
 
-### 9.0 What each change does to Vespa (and whether it needs a backfill)
+### 9.0 What each change does to Vespa (and how it's populated)
 
 | Schema change | Vespa behavior | Populated by |
 |---|---|---|
-| New rank profiles (`sort_followers`, edited `rank_*`) | online, instant; no data impact | — |
-| Extended `has_token_match` (matchCount username/nip05) | online (rank expr) | — |
-| New attribute `follower_counts` (tensor) | online; **empty** for existing docs | **score re-sync** (GrapeRank) |
-| New field `username` (indexed) | online; **empty** for existing docs | **kind-0 re-feed** (source data not in Vespa) |
-| `nip05`/`lud16`/`website` `summary` → `index\|summary` | indexing change; index **empty** for existing docs until rewritten | **kind-0 re-feed** (rewrites docs through the new pipeline) |
+| New rank profiles (`sort_followers`, edited `rank_*`, `text_relevance`) | online, instant | — |
+| Extended `has_token_match` / `secondary_active` (matchCount username/nip05) | online (rank expr) | — |
+| New attribute `follower_counts` (tensor<float>) | online; **empty** for existing docs | **score re-sync** (§9.2 step 4) |
+| New field `username` (indexed) | online; **empty** for existing docs | **kind-0 re-feed** (§9.2 step 5) |
+| `nip05`/`lud16`/`website` `summary` → `index\|summary` | **`indexing-change`** — rejected without `validation-overrides.xml`; index empty for existing docs until reindexed/re-fed | reindex from doc store and/or kind-0 re-feed |
 
-No change here drops data or requires a full reindex-from-scratch. **No
-downtime** at any step — schema changes are online and backfills are background.
+No change drops data or needs a reindex-from-scratch.
 
-### 9.1 Known unknowns to settle ON STAGING FIRST
+### 9.1 Prerequisite: the `indexing-change` override (validated, now in place)
 
-1. **Does `prepareandactivate` accept the `summary→index` change?** There is no
-   `validation-overrides.xml` in the app package, so if Vespa classifies this as
-   a change needing an override, the post-upgrade Job **fails loudly** (non-zero,
-   visible in `kubectl logs job/<release>-brainstorm-vespa-app-<rev>`). Fix:
-   add `vespa-app/validation-overrides.xml` allowing the flagged change, or split
-   the index-field change into its own later deploy.
-2. **There is no kind-0 re-feed tool.** `nostr_event_transferer` only re-syncs
-   kinds 3/10000/1984 — **not kind 0**. Populating `username` (and rewriting the
-   nip05/lud16/website indexes) needs a NEW small script: read kind-0 from the
-   internal strfry and call `vespa.upsert_profile` for each. Until that runs,
-   those fields stay empty for existing profiles (new/updated profiles fill in
-   organically as their kind-0 flows through `process_strfry_event`).
+The first deploy attempt to staging failed with:
 
-### 9.2 Sequence (run on staging, verify, then repeat on prod off-peak)
+```
+INVALID_APPLICATION_PACKAGE  indexing-change:
+  Field 'nip05'/'lud16'/'website' changed: add index aspect
+  ... To allow this add <allow until='yyyy-mm-dd'>indexing-change</allow> to validation-overrides.xml
+```
 
-1. **Pre-flight:** confirm a recent `brainstorm-backups-vespa` CronJob run; confirm
-   `vespa.appPackage.enabled=true`.
+This is Vespa's guardrail for turning a `summary` field into an indexed one (it
+implies reindexing), **not** a schema bug. Fix, added at
+`charts/brainstorm/vespa-app/validation-overrides.xml`:
+
+```xml
+<validation-overrides>
+    <allow until="2026-07-14">indexing-change</allow>
+</validation-overrides>
+```
+
+- **Auto-included** via the ConfigMap's `.Files.Glob "vespa-app/**"`
+  (`templates/vespa-app-deploy.yaml`) — no template change; lands at the package
+  root where Vespa expects it.
+- `until` must be **≤ 30 days** out; bump it if you deploy later than that.
+- **Remove it (or let it expire) once the change is live everywhere** — a
+  lingering override would silently wave through *future* accidental indexing
+  changes. Treat removal as a post-deploy cleanup task.
+
+The other schema changes (new `follower_counts`/`username` fields, new rank
+profiles) are additive and need no override.
+
+### 9.2 Sequence (staging first, verify, then prod off-peak)
+
+1. **Pre-flight:** recent `brainstorm-backups-vespa` run; `vespa.appPackage.enabled=true`;
+   `vespa-app/` contains both `doc.sd` and `validation-overrides.xml`.
 2. **Deploy schema + server together** (`helm upgrade`, per `charts/brainstorm/VESPA.md`).
-   The post-upgrade hook zips `vespa-app/` and POSTs it to
-   `:19071/.../prepareandactivate`. **Watch the Job log** (§9.1 item 1).
-   - *Impact now:* byText/NIP-50 immediately use `sort_followers`, but
-     `follower_counts` is empty → all same-tier hits tie at 0 followers → ordering
-     within a tier is flat until step 3. The `rank≥2` filter works immediately
-     (it reads the existing `quality_scores`). General name/display/about search
-     is unaffected. **Brief window:** if the server pod is ready before the
-     app-package Job activates, byText returns errors ("unknown rank profile
-     sort_followers") for a few seconds — re-run is harmless; the Job retries
-     config-server readiness.
-3. **Score re-sync** (populates `follower_counts` + applies `>0` ingest):
-   trigger GrapeRank for the default observer — admin
-   `POST /admin/brainstormPubkey/{pubkey}/trigger_graperank`, or wait for
-   `periodic_graperank_trigger`. `VESPA_FULL_SYNC=True` (already set) pushes every
-   rank>0 scorecard with its `trusted_followers`.
-   - *Impact:* a large bounded (`_BATCH_CONCURRENCY=32`) burst of partial-update
-     writes to Vespa; more rows than before (>0 vs ≥0.05). Search stays up; minor
-     latency bump under heavy feed. After it completes, follower-sort is live.
-4. **kind-0 re-feed** (populates `username`; rewrites nip05/lud16/website indexes)
-   — run the new re-feed script (§9.1 item 2). Bounded throughput; online.
-   - *Impact:* one partial-update per profile. `quality_scores`/`follower_counts`
-     tensors are preserved (partial update doesn't touch them). The skip-empty +
-     content/tags merge means no profile gets wiped.
-5. **Verify** with `scripts/search_http.sh` / `search_compare.sh` / `search_nip50.sh`:
-   popular-first ordering, `rank≥2` exclusion, `username`/`nip05` matches, and
+   The post-upgrade hook zips `vespa-app/` (now incl. the override) and POSTs to
+   `:19071/.../prepareandactivate`. **Watch**
+   `kubectl logs job/<release>-brainstorm-vespa-app-<rev>` — it should now activate.
+   - *Impact:* byText/NIP-50 immediately use `sort_followers`, but
+     `follower_counts` is empty → ordering within a tier is flat (ties at 0) until
+     step 4. The `rank≥2` filter works immediately (reads existing
+     `quality_scores`). name/display/about search is unaffected.
+   - **Seconds-long window:** if the server pod is ready before the app-package
+     activates, byText errors on "unknown rank profile `sort_followers`" — it
+     self-heals when the Job activates. To avoid it entirely, activate the schema
+     *before* rolling the server (manual `prepareandactivate`, then the upgrade).
+3. **(Optional) confirm reindex** of nip05/lud16/website from the doc store via the
+   config server's reindexing status. Step 5's re-feed rebuilds them regardless,
+   so this is belt-and-suspenders.
+4. **Score re-sync** → populates `follower_counts` + applies `>0` ingest:
+   - *Default experience (enough for anonymous/popular-first):* trigger the
+     default observer — `POST /admin/brainstormPubkey/{pubkey}/trigger_graperank`
+     or the periodic cronjob.
+   - *All personalized perspectives:* `python -m scripts.trigger_graperank_all
+     --status`, then `--rate N [--limit N]` (paced/resumable; tracks done via the
+     `brainstorm_request` table).
+   - *Impact:* bounded burst of partial-update writes (more rows: >0 vs ≥0.05);
+     GrapeRank itself is the heavy part — pace it. Search stays up.
+5. **kind-0 re-feed** → populates `username` + rebuilds nip05/lud16/website:
+   `python -m scripts.refeed_kind0_to_vespa --status`, then `--concurrency N
+   [--limit N]` (resumable via its cursor).
+   - *Impact:* one partial-update per profile; `quality_scores`/`follower_counts`
+     tensors are preserved; skip-empty + content/tags merge means nothing gets wiped.
+6. **Verify** with `scripts/search_http.sh` / `search_compare.sh` / `search_nip50.sh`:
+   popular-first ordering, `rank≥2` exclusion, `username`/`nip05` matches, and the
    `sort=rank` / `sort=text` alternates.
 
 ### 9.3 Rollback
 
 `helm rollback` (or redeploy the prior chart) reverts the rank profiles and the
 server. The added `follower_counts`/`username` fields and any written cells are
-**harmless to leave** — the previous profiles simply don't read them, and no data
-is lost. The `summary→index` change is the only one that isn't a clean auto-revert
-(removing an index may need an override); prefer rolling *forward* (fix + redeploy)
-over rolling back that specific field.
+**harmless to leave** — the previous profiles don't read them, and no data is
+lost. The `summary→index` change is the only one that isn't a clean auto-revert
+(removing an index aspect would itself need an override); prefer rolling *forward*
+(fix + redeploy) over reverting that specific field.
 
 ### 9.4 Degraded-but-functional windows (summary)
 
 | Between… | Search still works? | What's missing |
 |---|---|---|
-| schema deploy → score re-sync | yes | follower ordering is flat (ties at 0) |
-| schema deploy → kind-0 re-feed | yes | username / nip05 / lud16 / website matches on existing profiles |
+| schema deploy → score re-sync | yes | follower ordering is flat (ties at 0); `rank≥2` filter already works |
+| schema deploy → reindex/re-feed | yes | `nip05`/`lud16`/`website` matches (reindex from store), `username` matches (re-feed) on existing profiles |
 | server ready → app-package active | ~no (seconds) | byText errors on unknown profile until the Job activates |
+
+### 9.5 Post-deploy cleanup
+
+- Remove `vespa-app/validation-overrides.xml` (§9.1) once the indexing change is
+  activated everywhere it needs to be, and redeploy.
+- Once the index is in steady state, consider flipping `VESPA_FULL_SYNC` to
+  `False` (`upload_nostr_events.py`) so routine GrapeRank runs only push *changed*
+  scores instead of the full set.

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -672,9 +672,10 @@ gram / recall noise                              ← neither
   the tier is visible per result.
 
 **Scope:** the bio (`about`) and the account's own `website` domain feed this
-tier; `lud16` stays pure recall. Extend `_field_role` in `app/core/vespa.py` if
-lud16 affiliation should also count. Note impersonators *named* the query stay in
-the name tier — verified-follower ordering within that tier (once ingest
+tier. `lud16` is treated like `nip05` — both are `@`-address identity fields, so
+it's a **primary/name-tier** field (`_PRIMARY_FIELDS` + `matchCount(lud16)` in
+`has_token_match()`), not affiliation. Note impersonators *named* the query stay
+in the name tier — verified-follower ordering within that tier (once ingest
 completes) is what sinks them beneath the real account.
 
 ### 11.1 itemRawScore doesn't work for text terms — the exactness ladder is deferred

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -1,0 +1,196 @@
+# How tapestry searches (Meilisearch) vs. us (Vespa) — what to learn
+
+_Last updated: 2026-06-29. Owner: search. Audience: the team. Purpose: the team
+asked us to mimic tapestry's Nostr-profile search with Vespa; some testers feel
+Meilisearch returns better results. This explains **why** the results differ and
+**what is worth porting** to our Vespa rank profile._
+
+> Cross-refs: [`search-precision-and-filtering.md`](search-precision-and-filtering.md)
+> (text-vs-text fixes) and [`search-trust-vs-exact-match.md`](search-trust-vs-exact-match.md)
+> (the additive-trust swamping bug). This doc is the layer above those: a
+> head-to-head with tapestry's implementation.
+
+Tapestry source explored: `nostr-search/` (the Meilisearch index + search API),
+`nip50-proxy/` (the NIP-50 relay), `src/algos/nip85/` and
+`src/api/search/profiles/meili/` (WoT score loading), plus
+`nostr-search/BIBLE.md` and `engineering-team/epics/search-quality.md`.
+
+---
+
+## TL;DR
+
+1. **The single biggest difference: tapestry never blends trust into text
+   relevance.** Meilisearch ranks purely on text; Web-of-Trust scores are a
+   separate numeric **sort/filter** dimension applied in a two-phase search. Our
+   Vespa profile *adds* `quality_boost` (0–1000) into a ~100-scale text score, so
+   trust distorts ordering. This is the same swamping pathology documented in
+   `search-trust-vs-exact-match.md` — tapestry's architecture cannot have it.
+2. **Exactness and field-priority are first-class ranking rules** in Meilisearch,
+   not hand-tuned constants. We re-implement them by hand and it's brittle.
+3. **Tapestry searches more fields** (`nip05`, `npub`, `username`, `lud16`,
+   `website`), does **NIP-05 `.well-known` verification**, and uses **length-gated
+   typo tolerance + proximity**. We do none of these yet.
+4. The way to know whether we've closed the gap is an **offline eval harness**
+   (recall@k / MRR over a judged gold set) — which tapestry is also building.
+   "Feels better" is currently anecdotal on both sides.
+
+---
+
+## 1. The architecture difference (the important part)
+
+### Tapestry: text and trust are orthogonal
+
+Meilisearch index settings (`nostr-search/src/ingest.js:38-66`):
+
+```javascript
+searchableAttributes: [           // ORDER = field weight (name highest)
+  'name', 'display_name', 'displayName', 'username',
+  'nip05', 'npub', 'about', 'lud16', 'website',
+],
+rankingRules: [                   // stock lexicographic ladder
+  'words', 'typo', 'proximity', 'attribute', 'sort', 'exactness',
+],
+typoTolerance: { enabled: true, minWordSizeForTypos: { oneTypo: 3, twoTypos: 6 } },
+```
+
+WoT scores are **not** in those rules. They are stored as separate numeric fields
+namespaced per observer — `wot_rank_<8charPovSuffix>`, `wot_followers_<suffix>`
+(`src/algos/nip85/loadScoresIntoMeilisearch.js:88-99`) — registered as
+`filterable`/`sortable` at score-load time, and applied via a **two-phase search**
+(`nostr-search/src/search.js:76-140`):
+
+- **Phase 1** — run the text query over WoT-scored profiles (optionally filtered
+  to `score > 0`), then **re-sort that set by the trust field** in JS (Meilisearch
+  `sort` is only a tiebreaker within text tiers, so they re-sort to force order).
+- **Phase 2** — if no filters are set, **backfill** with unscored text matches so
+  non-scored profiles are still discoverable, ranked after the scored ones.
+
+The NIP-50 proxy defaults to `sort:followers:desc` when the client sends no sort
+token (`nip50-proxy/src/search.js:111-166`). So tapestry's **default ordering is
+"text matches, sorted by trust within"** — never "text score + trust score."
+
+### Us: text and trust are added together
+
+Our default Vespa profile `name_and_quality_score_only`:
+
+```
+relevance() = has_token_match()*1100 + primary_text() + secondary*about + quality_boost()
+                                        └── ~0..200 ──┘                    └── 0..1000 ──┘
+```
+
+`quality_boost()` is additive and ~10× the text scale. The `has_token_match` tier
+(added in `search-trust-vs-exact-match.md`) keeps real matches above trigram
+noise, but **within the matched set, trust still dominates ordering** — which is
+*not* what Meilisearch does.
+
+**Why this makes their results "better":** exact/text relevance is never distorted
+by trust. Trust only reorders *within* an already-text-correct result set. We're
+still mixing the two signals on one axis.
+
+---
+
+## 2. Side-by-side
+
+| Dimension | tapestry (Meilisearch) | us (Vespa) |
+|---|---|---|
+| Text ranking | Stock ladder: words→typo→proximity→attribute→sort→exactness | Hand-rolled `matchCount*100 + bm25/len + grams` |
+| Trust integration | **Separate** numeric field; sort/filter; two-phase | **Additive** `quality_boost` in `relevance()` |
+| Exact-match priority | `exactness` ranking rule (structural) | `has_token_match()*1100` tier (manual) |
+| Field priority | `searchableAttributes` order (name>…>about) | `primary_text = max(name,display_name)`, about gated |
+| Searchable fields | name, display_name, username, **nip05, npub**, about, **lud16, website** | name, display_name, about (+ `*_gram`) |
+| Typo tolerance | Length-gated: ≥3→1 typo, ≥6→2 | Fuzzy `maxEditDistance:1, prefixLength:2` + **trigram OR firehose** |
+| Prefix / search-as-you-type | On by default | `prefix:true` userInput clause |
+| Proximity (multi-word) | `proximity` ranking rule | None (per-word OR groups + CamelCase-join variant) |
+| NIP-05 verification | Parallel `.well-known/nostr.json` lookup + surface verified hit | None |
+| Per-observer scores | `wot_<metric>_<suffix>` fields; **mutates index settings at runtime**; **prunes unscored** to bound size | Sparse `quality_scores` tensor `tensor<int8>(user{})` — no schema mutation, no pruning |
+| Dedup | pubkey primary key, keep latest `created_at` | pubkey docid, partial-update upsert |
+| Broad-query robustness | Must **catch a Meilisearch panic** on queries like "primal" and return "too broad" | Handles broad queries fine |
+| Quality measurement | Building recall@k / MRR eval harness (judged gold set) | None yet |
+
+---
+
+## 3. Why results are "slightly different" (concrete causes)
+
+1. **Ordering** differs because we add trust to relevance and they sort by it
+   separately. Same matches, different order.
+2. **Recall** differs: a query that hits `nip05`/`npub`/`username`/`website`
+   finds the profile in tapestry, not in our index.
+3. **NIP-05** queries (`name@domain`) surface a verified profile at the top in
+   tapestry; we treat it as plain text.
+4. **Typo candidate sets** differ: length-gated typos vs. our trigram-OR recall
+   pull in different neighbours, which shifts both recall and order.
+5. **Multi-word** queries: their `proximity` rule rewards token closeness; we have
+   no proximity signal.
+
+---
+
+## 4. What to port to Vespa (prioritized)
+
+| # | Change | Vespa mechanism | Effort | Impact |
+|---|---|---|---|---|
+| **P0** | **Stop adding trust into relevance.** Default profile = pure text + exactness tier; expose trust only as sort/filter (we already have `rank_desc` / `rank_filtered`). Mirrors tapestry's two-phase. | Remove `quality_boost()` from `relevance()`; keep the `has_token_match` tier; route trust through the `rank_*` profiles / a `second-phase` | Low–med | **Highest** |
+| **P1** | Index `nip05, npub, username, lud16, website` as searchable; add to YQL word groups | schema fields + `_word_group` in `app/core/vespa.py` | Low | High (recall parity) |
+| **P2** | NIP-05 `.well-known/nostr.json` verify + surface the verified hit (dedup) | new path in `app/routers/search/router.py` | Med | Med |
+| **P3** | Align typo budget to length-gated (≥3→1, ≥6→2); lean less on grams | `_word_max_edits`, lower `query(w_gram)` | Low | Med |
+| **P4** | Add proximity for multi-word | `nativeProximity` / `fieldMatch` term in the rank profile | Med | Med |
+| **P5** | **Search-eval harness** (recall@k / MRR over a hand-judged gold set, ~30 queries) | offline test; reuse `scripts/search_*.sh` to capture rankings | Med | **Process** |
+
+**P0 is the highest-leverage change** and directly removes the swamping that
+`search-trust-vs-exact-match.md` is about. **P5 is what makes "is it actually
+better?" answerable** instead of anecdotal — tapestry is building the same harness
+(`engineering-team/epics/search-quality.md`) for exactly this reason.
+
+---
+
+## 5. Where we're already equal or better (don't over-correct)
+
+- **Per-observer trust storage.** Our sparse `quality_scores` tensor is cleaner
+  than tapestry's `wot_<metric>_<suffix>` fields, which require mutating the
+  index's `filterable`/`sortable` settings at runtime per observer and **pruning
+  unscored profiles** to keep the index small. We need neither.
+- **Robustness.** Tapestry has to catch a Meilisearch v1.12.8 interner panic on
+  broad queries (e.g. "primal") and return a "query too broad" notice
+  (`nostr-search/src/search.js:144-170`). Vespa handles those queries.
+- **Diacritics / case.** Vespa's default linguistics already lowercases and
+  normalizes accents on indexed string fields — comparable to Meilisearch's
+  tokenizer, so this is not a differentiator.
+
+---
+
+## 6. The one architecture decision for the team
+
+Tapestry's default NIP-50 ordering is `sort:followers:desc` — text matches sorted
+by trust *within*. That is the clean version of what our additive `quality_boost`
+was clumsily approximating. So we need to choose our **default** ordering:
+
+- **Pure text relevance** (like tapestry's `/api/search` with no sort), or
+- **Trust-sorted-within-text** (like tapestry's NIP-50 default).
+
+Recommendation: **pure-text default for `/search/byText`, trust-sort for the
+NIP-50 relay** — matching tapestry exactly. This decides whether P0 means "drop
+`quality_boost` entirely" or "move it to a second-phase sort."
+
+---
+
+## 7. Suggested next steps
+
+1. Decide the default-ordering question in §6.
+2. Prototype P0 on a branch; A/B against the current profile on staging using
+   `scripts/search_compare.sh` and `scripts/search_http.sh`.
+3. Land P1 (more searchable fields) — cheapest recall win; needs a reindex/refeed
+   only for the new fields.
+4. Stand up the P5 eval harness with a small judged gold set so every later change
+   is measured, not guessed.
+
+### Reference: key tapestry files
+
+| Concern | File |
+|---|---|
+| Index settings / ranking rules | `nostr-search/src/ingest.js:38-66` |
+| Document fields | `nostr-search/src/ingest.js:130-149` |
+| Two-phase search + re-sort | `nostr-search/src/search.js:76-140` |
+| Broad-query panic workaround | `nostr-search/src/search.js:144-170` |
+| WoT score load / namespacing | `src/algos/nip85/loadScoresIntoMeilisearch.js:88-99` |
+| NIP-05 verify + dedup | `src/api/search/profiles/meili/index.js:26-46, 209-214` |
+| NIP-50 parse / execute | `nip50-proxy/src/search.js:25-62, 111-166` |
+| Design rationale | `nostr-search/BIBLE.md:201, 305-318`; `engineering-team/epics/search-quality.md` |

--- a/docs/search-vs-tapestry.md
+++ b/docs/search-vs-tapestry.md
@@ -295,9 +295,13 @@ Fix (build with P1, not a JSON-only `username` add):
   `[key, value]` profile tags, with a precedence rule (content wins; tags fill
   gaps).
 - Normalize aliases: `displayName` → `display_name`, etc.
-- **Don't-clear guard:** never overwrite an existing non-empty field with `""`
-  from a *less-complete* event, so a sparse tag-only update can't wipe a good
-  profile.
+- **Skip-empty guard:** if the merged result has *no* recognized profile fields
+  (truly empty/malformed event), skip the upsert entirely — `upsert_profile`
+  clears missing fields to `""`, so an empty event would otherwise wipe a good
+  profile. (We deliberately do *not* do a per-field "don't clear" guard: kind-0
+  is a replaceable full-profile event in Nostr, so a field genuinely omitted by
+  a complete event *should* clear. The merge makes tag-only events non-empty, so
+  they no longer trigger the wipe.)
 - Then extract the expanded `PROFILE_FIELDS` (now including `username`).
 
 ### 8.5 Backfill / deploy — one maintenance window

--- a/env.example
+++ b/env.example
@@ -17,3 +17,7 @@ BLOCK_FREQUENT_GRAPERANK_REQUESTS=false
 BLOCK_FREQUENT_GRAPERANK_REQUESTS_MINUTES=30
 PERIODIC_GRAPERANK_PUBKEY=
 VESPA_URL=http://localhost:8080
+# Open Ranking auth posture. false = open/unauthenticated (uses the public
+# global observer + client-supplied pov). true = require a valid NWT and force
+# every query to the signer's own observer perspective (pov is ignored).
+OPEN_RANKING_REQUIRE_AUTH=false

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -59,6 +59,23 @@ need **no `.env`**; override the target via `BRAINSTORM_HTTP` / `BRAINSTORM_WS`.
   default. Needs `requests` + `nostr-sdk` (poetry env), like
   `smoke_open_ranking.py`; no `.env` required.
 
+### `trigger_graperank_all.py`
+
+Bulk-re-runs GrapeRank for **every** observer in `brainstorm_nsec` — the backfill
+lever for repopulating per-observer Vespa tensors (e.g. the new `follower_counts`,
+docs/search-vs-tapestry.md §8/§9). GrapeRank is expensive per observer, so:
+
+- `--rate N` enqueues/min, `--limit N` cap per run — tune to the worker's throughput.
+- Resumable + observable via the `brainstorm_request` table (no fragile state):
+  a campaign starts at time T (stored in `--state-file`); an observer is
+  *triggered* if it has a `graperank` request since T and *completed* when that
+  request hits `success`. Re-running skips already-triggered observers.
+- `--status` (counts, no writes), `--dry-run` (preview). Run **inside a
+  brainstorm-server pod** (needs `.env` + DB + the graperank worker consuming).
+
+Note: the default observer alone covers anonymous/default search; this is for
+populating ALL personalized perspectives at once. See §8.5/§9.
+
 ## When to add a new script
 
 Add one if:

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -31,6 +31,34 @@ Smoke test for `/admin/nsec-encryption/rotate` + `/verify`:
 
 Run after touching `app/services/nsec_encryption_service.py` or `app/utils/encryption.py`.
 
+### Search testing helpers (`search_*.sh`, `search_open_ranking.py`)
+
+Ad-hoc tools for poking the three search surfaces against a **deployed** host
+(default: staging). The `.sh` ones are stdlib-only (curl/websocat/python3) and
+need **no `.env`**; override the target via `BRAINSTORM_HTTP` / `BRAINSTORM_WS`.
+
+- **`search_http.sh "<query>" [maxHits] [--all] [--tsv]`** — `GET /search/byText`
+  (the default-observer path the UI uses logged-out). Prints rank order with
+  `_relevance` + `_quality_score` so you can see *why* it ordered that way.
+- **`search_nip50.sh "<search string>" [limit] [--tsv]`** — drives the NIP-50
+  relay over a websocket. Put NIP-50 tokens in the search string to test them:
+  `observer:<hex>` (rank POV), `sort:rank:desc|asc`, `filter:rank:gte:N`.
+- **`search_compare.sh "<query>" [limit]`** — runs the HTTP + NIP-50 paths for
+  the same query and prints them side by side, flagging divergence. Both share
+  `app.core.vespa.search`, so a plain query matches; divergence means the NIP-50
+  side resolved a different observer or a sort/filter profile. See
+  `docs/search-trust-vs-exact-match.md`.
+- **`search_open_ranking.sh "<query>" [limit] [--pov <hex>] [--algo <id>]`** —
+  ORE-05 `POST /search/pubkeys`, **unsigned** (ORE-05 auth is optional and
+  currently off). Stdlib-only. `--pov` only matters with a *personalized*
+  algorithm, so it auto-selects `name-trust-pov` (the default `name-trust` is
+  global and ignores pov per ORE-01).
+- **`search_open_ranking.py --query <q> [--pov <hex>] [--algo <id>] [--sign|--nsec ...]`**
+  — same endpoint, but can **sign** an NWT so the observer = signer. Observer
+  priority: signer (when signed) → `--pov` (auto `name-trust-pov`) → server
+  default. Needs `requests` + `nostr-sdk` (poetry env), like
+  `smoke_open_ranking.py`; no `.env` required.
+
 ## When to add a new script
 
 Add one if:

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -76,6 +76,22 @@ docs/search-vs-tapestry.md §8/§9). GrapeRank is expensive per observer, so:
 Note: the default observer alone covers anonymous/default search; this is for
 populating ALL personalized perspectives at once. See §8.5/§9.
 
+### `refeed_kind0_to_vespa.py`
+
+Re-feeds every kind-0 profile from the internal strfry into Vespa via the SAME
+ingest path the live consumer uses (`process_event_kind_0` → content/tags merge →
+`upsert_profile`). The backfill for P1 (docs/search-vs-tapestry.md §8.4/§9):
+populates the new `username` field and rebuilds the newly-indexed
+`nip05`/`lud16`/`website` fields for existing docs. The transferer only handles
+kinds 3/10000/1984, so this is the only kind-0 → Vespa re-feed path.
+
+- **Requires the schema changes deployed first** (username + indexed fields) —
+  else every `upsert_profile` fails on an unknown field.
+- Walks kind-0 newest→oldest by `until` cursor, dedups by pubkey, writes the
+  cursor to `--state-file` after each page → resumable.
+- `--concurrency` (parallel Vespa writes), `--page`, `--limit`, `--status`,
+  `--dry-run`. Run inside a brainstorm-server pod (needs `.env` + strfry + Vespa).
+
 ## When to add a new script
 
 Add one if:

--- a/scripts/analyze_pubkey.py
+++ b/scripts/analyze_pubkey.py
@@ -1,0 +1,135 @@
+"""Explain how ONE pubkey matches + ranks for a query — a search debugger.
+
+Given a pubkey and a query, this:
+  1. fetches the doc's stored fields,
+  2. runs the REAL search YQL (shared `app.core.vespa_query.build_query`, so it
+     never drifts from production) restricted to that one doc, and dumps the
+     decisive rank signals — matchCount per field, has_token_match,
+     affiliation_match, match_quality, the derived tier, and relevance,
+  3. runs the full search and reports where the doc actually lands.
+
+Stdlib-only (urllib) and imports only the dependency-free query builder, so it
+runs WITHOUT a populated .env — point it at a port-forwarded Vespa:
+
+    kubectl -n <ns> port-forward svc/brainstorm-vespa 8080:8080 &
+    VESPA_URL=http://localhost:8080 python -m scripts.analyze_pubkey <pubkey|npub> "<query>"
+
+Flags:
+    --profile P    rank profile (default sort_followers — the byText default)
+    --observer HEX pass observer for user_q so _quality_score/_followers are real
+    --vespa URL    overrides $VESPA_URL (default http://localhost:8080)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.vespa_query import build_query  # noqa: E402
+
+SEARCH_FIELDS = ("name", "display_name", "username", "nip05", "lud16", "website", "about")
+
+
+def _get(url: str) -> dict:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return {}
+        raise
+
+
+def _tier(mf: dict) -> str:
+    mq = mf.get("match_quality") or 0
+    if mq and int(mq) > 0:
+        return {4: "exact", 3: "prefix", 2: "1-typo", 1: "2-typo"}.get(int(mq), str(mq))
+    if mf.get("has_token_match"):
+        return "name"
+    if mf.get("affiliation_match"):
+        return "affiliation"
+    return "gram"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("pubkey", help="hex pubkey (64 hex chars)")
+    p.add_argument("query")
+    p.add_argument("--profile", default="sort_followers")
+    p.add_argument("--observer", default=None)
+    p.add_argument("--vespa", default=None)
+    args = p.parse_args()
+
+    vespa = (args.vespa or os.environ.get("VESPA_URL", "http://localhost:8080")).rstrip("/")
+    pk = args.pubkey.lower()
+
+    # 1) stored fields
+    doc = _get(f"{vespa}/document/v1/doc/doc/docid/{pk}").get("fields", {})
+    if not doc:
+        print(f"no doc for pubkey {pk}")
+        return 1
+    print(f"=== {pk[:16]}…  query={args.query!r}  profile={args.profile} ===")
+    print("--- stored fields ---")
+    for f in SEARCH_FIELDS:
+        v = doc.get(f)
+        if v:
+            print(f"  {f:13} {v[:80]!r}")
+
+    # 2) isolate this doc under the real YQL + rank features
+    _words, yql, wparams = build_query(args.query)
+    yql = yql.replace("where ", f'where pubkey contains "{pk}" and ', 1)
+    params = {"yql": yql, "ranking": args.profile, "hits": "1", **wparams}
+    if args.observer:
+        params["ranking.features.query(user_q)"] = "{" + args.observer.lower() + ":1.0}"
+    hit = (_get(f"{vespa}/search/?" + urllib.parse.urlencode(params))
+           .get("root", {}).get("children", []) or [{}])[0]
+    mf = hit.get("fields", {}).get("matchfeatures", {})
+
+    # Which fields match, and via which clause — reliable per-field/kind probes
+    # (a field-restricted "does this doc appear?"). NB Vespa's listFeatures
+    # matchCount(...) proved unreliable here, so we probe instead.
+    print("--- which fields match (per-clause) ---")
+
+    def _probe(field: str, ann: str) -> bool:
+        yq = f'select pubkey from doc where pubkey contains "{pk}" and ({{defaultIndex:"{field}"{ann}}}userInput(@q))'
+        pp = {"yql": yq, "q": args.query, "ranking": "unranked", "hits": "1"}
+        got = _get(f"{vespa}/search/?" + urllib.parse.urlencode(pp)).get("root", {}).get("children", [])
+        return bool(got)
+
+    kinds = [("exact", ""), ("prefix", ",prefix:true"),
+             ("fuzzy", ",fuzzy:{maxEditDistance:1,prefixLength:2}")]
+    any_match = False
+    for f in SEARCH_FIELDS:
+        got = [k for k, ann in kinds if _probe(f, ann)]
+        if got:
+            any_match = True
+            print(f"  {f:13} matched via: {', '.join(got)}")
+    if not any_match:
+        print("  (no field matched — recall miss)")
+    print(f"  has_token_match={mf.get('has_token_match')}  "
+          f"affiliation_match={mf.get('affiliation_match')}  "
+          f"match_quality={mf.get('match_quality')}")
+    print(f"  TIER = {_tier(mf)}   relevance = {hit.get('relevance')}")
+
+    # 3) actual rank position in the full result set
+    fp = dict(params)
+    fp["yql"] = build_query(args.query)[1]  # unfiltered
+    fp["hits"] = "400"
+    fp.pop("ranking.listFeatures", None)
+    kids = _get(f"{vespa}/search/?" + urllib.parse.urlencode(fp)).get("root", {}).get("children", [])
+    pos = next((i for i, h in enumerate(kids)
+                if h.get("fields", {}).get("pubkey", "").lower() == pk), None)
+    print(f"--- rank position: {pos if pos is not None else 'NOT in top 400'} "
+          f"of {len(kids)} ---")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_pubkey.py
+++ b/scripts/analyze_pubkey.py
@@ -34,7 +34,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from app.core.vespa_query import build_query  # noqa: E402
 
-SEARCH_FIELDS = ("name", "display_name", "username", "nip05", "lud16", "website", "about")
+SEARCH_FIELDS = ("name", "display_name", "nip05", "lud16", "website", "about")
 
 
 def _get(url: str) -> dict:

--- a/scripts/list_observer_signers.py
+++ b/scripts/list_observer_signers.py
@@ -1,0 +1,70 @@
+"""
+List all observers and their derived signing pubkeys.
+
+For each row in the `brainstorm_nsec` table this prints:
+    <observer_pubkey>\t<signing_pubkey>
+
+The signing pubkey is what appears as the `pubkey` field on the kind-30382
+TA-score events published to the relay. Because the relay aggregates events
+across all environments, you must run this inside the env (pod) whose DB
+you want to enumerate.
+
+Usage (from a brainstorm-server pod):
+    python -m scripts.list_observer_signers
+    python -m scripts.list_observer_signers --tsv > signers.tsv
+    python -m scripts.list_observer_signers --signers-only
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+# Allow running as a plain script: `python scripts/list_observer_signers.py`
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select  # noqa: E402
+from nostr_sdk import Keys  # noqa: E402
+
+from app.core.database import db_session  # noqa: E402
+from app.db_models import BrainstormNsec  # noqa: E402
+from app.utils.encryption import decrypt_nsec  # noqa: E402
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--signers-only",
+        action="store_true",
+        help="Only print signing pubkeys (one per line).",
+    )
+    parser.add_argument(
+        "--tsv",
+        action="store_true",
+        help="Print a header line and tab-separated columns.",
+    )
+    args = parser.parse_args()
+
+    async with db_session() as db:
+        rows = (await db.execute(select(BrainstormNsec))).scalars().all()
+
+    if args.tsv and not args.signers_only:
+        print("observer_pubkey\tsigning_pubkey")
+
+    for row in rows:
+        nsec = decrypt_nsec(row.encrypted_nsec) if row.encrypted_nsec else row.nsec
+        try:
+            signer = Keys.parse(secret_key=nsec).public_key().to_hex()
+        except Exception as e:  # noqa: BLE001
+            print(f"# failed to parse nsec for observer {row.pubkey}: {e}",
+                  file=sys.stderr)
+            continue
+
+        if args.signers_only:
+            print(signer)
+        else:
+            print(f"{row.pubkey}\t{signer}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/refeed_kind0_to_vespa.py
+++ b/scripts/refeed_kind0_to_vespa.py
@@ -1,0 +1,185 @@
+"""Re-feed kind-0 profiles from the internal strfry into Vespa — paced + resumable.
+
+Backfill lever for the P1 profile fields (docs/search-vs-tapestry.md §8.4/§9):
+the transferer only re-syncs kinds 3/10000/1984, so there is no built-in way to
+re-process kind-0 → Vespa. This script reads every kind-0 from the internal
+strfry and runs each through the SAME ingest path the live consumer uses
+(`process_event_kind_0` → content/tags merge → `upsert_profile`). That:
+
+  * populates the new `username` field (not in Vespa's doc store, only in the
+    kind-0 source), and
+  * rewrites every profile through the updated indexing pipeline, so the newly
+    indexed `nip05`/`lud16`/`website` fields get built for existing docs.
+
+REQUIRES the schema changes (username + the indexed fields) to be DEPLOYED first
+— otherwise every `upsert_profile` fails on an unknown field.
+
+It walks kind-0 newest→oldest by `until` cursor, de-duplicates by pubkey within
+the run (first/newest wins; kind-0 is replaceable so strfry should already keep
+only the latest), and writes the cursor to a state file after each page so a
+re-run RESUMES from where it stopped.
+
+Run from a brainstorm-server pod / the container (needs a populated `.env` and
+network access to strfry + Vespa):
+
+    python -m scripts.refeed_kind0_to_vespa --status        # cursor + processed so far
+    python -m scripts.refeed_kind0_to_vespa --dry-run       # fetch + count, no writes
+    python -m scripts.refeed_kind0_to_vespa --concurrency 16 --limit 5000
+    python -m scripts.refeed_kind0_to_vespa --concurrency 16   # resume until drained
+
+Flags:
+    --relay-url URL   strfry websocket (default: settings.nip50_backing_relay_url)
+    --concurrency N   parallel upserts to Vespa (default 16)
+    --page N          events per strfry REQ page (default 500)
+    --limit N         max events to PROCESS this invocation (default: no cap)
+    --state-file P    resume cursor json (default ./refeed_kind0_state.json)
+    --status          print cursor + processed count and exit
+    --dry-run         fetch + count, do not call upsert
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import websockets
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.config import settings  # noqa: E402
+from app.core.vespa import aclose as vespa_aclose  # noqa: E402
+from app.message_queue_tasks.process_strfry_event import (  # noqa: E402
+    process_event_kind_0,
+)
+
+_DEFAULT_STATE = "refeed_kind0_state.json"
+_SUB = "refeed"
+
+
+def _load_state(path: Path) -> dict:
+    if path.exists():
+        return json.loads(path.read_text())
+    return {"cursor": None, "processed": 0}
+
+
+def _save_state(path: Path, state: dict) -> None:
+    path.write_text(json.dumps(state, indent=2))
+
+
+async def _fetch_page(url: str, until: int | None, limit: int, timeout: float) -> list[dict]:
+    """One NIP-01 REQ for kind-0, returning the events (newest-first)."""
+    flt: dict = {"kinds": [0], "limit": limit}
+    if until is not None:
+        flt["until"] = until
+    req = json.dumps(["REQ", _SUB, flt])
+    events: list[dict] = []
+    async with websockets.connect(url, open_timeout=timeout, max_size=None) as ws:
+        await ws.send(req)
+        while True:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+            except asyncio.TimeoutError:
+                break  # treat a stall as end-of-page
+            try:
+                msg = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(msg, list) or len(msg) < 2 or msg[1] != _SUB:
+                continue
+            if msg[0] == "EVENT" and len(msg) >= 3:
+                events.append(msg[2])
+            elif msg[0] in ("EOSE", "CLOSED"):
+                try:
+                    await ws.send(json.dumps(["CLOSE", _SUB]))
+                except Exception:
+                    pass
+                break
+    return events
+
+
+async def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--relay-url", default=settings.nip50_backing_relay_url)
+    p.add_argument("--concurrency", type=int, default=16)
+    p.add_argument("--page", type=int, default=500)
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--state-file", default=_DEFAULT_STATE)
+    p.add_argument("--status", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--timeout", type=float, default=10.0)
+    args = p.parse_args()
+
+    state_path = Path(args.state_file)
+    state = _load_state(state_path)
+
+    if args.status:
+        print(f"relay      : {args.relay_url}")
+        print(f"cursor     : {state['cursor']}  (oldest created_at processed; "
+              f"None = not started)")
+        print(f"processed  : {state['processed']}")
+        return 0
+
+    print(f"re-feed kind-0 from {args.relay_url} "
+          f"(resume cursor={state['cursor']}, processed={state['processed']})")
+
+    sem = asyncio.Semaphore(args.concurrency)
+    seen: set[str] = set()
+    processed_this_run = 0
+    cursor = state["cursor"]
+
+    async def _process(ev: dict) -> None:
+        async with sem:
+            await process_event_kind_0(ev)
+
+    try:
+        while True:
+            page = await _fetch_page(args.relay_url, cursor, args.page, args.timeout)
+            if not page:
+                print("drained: no more kind-0 events.")
+                break
+
+            fresh = []
+            for ev in page:
+                pk = ev.get("pubkey")
+                if isinstance(pk, str) and pk not in seen:
+                    seen.add(pk)
+                    fresh.append(ev)
+
+            if not args.dry_run and fresh:
+                await asyncio.gather(*(_process(ev) for ev in fresh))
+
+            processed_this_run += len(fresh)
+            state["processed"] += len(fresh)
+
+            oldest = min(ev.get("created_at", 0) for ev in page)
+            # `until` is inclusive; advancing to `oldest` re-fetches the boundary
+            # event(s) (the seen-set drops them). Guard against a no-progress loop
+            # when a whole full page shares one timestamp.
+            if cursor is not None and oldest >= cursor and len(page) >= args.page:
+                oldest = cursor - 1
+            cursor = oldest
+            state["cursor"] = cursor
+            if not args.dry_run:
+                _save_state(state_path, state)
+
+            print(f"  page: {len(page)} fetched, {len(fresh)} new "
+                  f"(run total {processed_this_run}); cursor={cursor}")
+
+            if args.limit is not None and processed_this_run >= args.limit:
+                print(f"hit --limit {args.limit}; stopping (re-run to continue).")
+                break
+            if len(page) < args.page:
+                print("drained: last (short) page.")
+                break
+    finally:
+        await vespa_aclose()
+
+    print(f"done: processed {processed_this_run} profile(s) this run "
+          f"({state['processed']} total).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/refeed_kind0_to_vespa.py
+++ b/scripts/refeed_kind0_to_vespa.py
@@ -127,6 +127,7 @@ async def main() -> int:
     sem = asyncio.Semaphore(args.concurrency)
     seen: set[str] = set()
     processed_this_run = 0
+    failed_this_run = 0
     cursor = state["cursor"]
 
     async def _process(ev: dict) -> None:
@@ -148,7 +149,20 @@ async def main() -> int:
                     fresh.append(ev)
 
             if not args.dry_run and fresh:
-                await asyncio.gather(*(_process(ev) for ev in fresh))
+                # return_exceptions=True so one malformed profile (e.g. Vespa
+                # rejecting a leftover control char in `name`) is logged and
+                # skipped instead of aborting the whole backfill. The page still
+                # completes, so the cursor advances past the bad doc on resume.
+                results = await asyncio.gather(
+                    *(_process(ev) for ev in fresh), return_exceptions=True
+                )
+                errs = [r for r in results if isinstance(r, BaseException)]
+                if errs:
+                    failed_this_run += len(errs)
+                    for e in errs[:3]:
+                        print(f"  skip (upsert failed): {e!r}")
+                    if len(errs) > 3:
+                        print(f"  ... +{len(errs) - 3} more upsert failures this page")
 
             processed_this_run += len(fresh)
             state["processed"] += len(fresh)
@@ -176,8 +190,9 @@ async def main() -> int:
     finally:
         await vespa_aclose()
 
+    skipped = f", {failed_this_run} skipped (upsert errors)" if failed_this_run else ""
     print(f"done: processed {processed_this_run} profile(s) this run "
-          f"({state['processed']} total).")
+          f"({state['processed']} total){skipped}.")
     return 0
 
 

--- a/scripts/refeed_kind0_to_vespa.py
+++ b/scripts/refeed_kind0_to_vespa.py
@@ -6,13 +6,13 @@ re-process kind-0 → Vespa. This script reads every kind-0 from the internal
 strfry and runs each through the SAME ingest path the live consumer uses
 (`process_event_kind_0` → content/tags merge → `upsert_profile`). That:
 
-  * populates the new `username` field (not in Vespa's doc store, only in the
-    kind-0 source), and
+  * folds the deprecated `username` into `name` where `name` is empty (NIP-24),
+    and
   * rewrites every profile through the updated indexing pipeline, so the newly
     indexed `nip05`/`lud16`/`website` fields get built for existing docs.
 
-REQUIRES the schema changes (username + the indexed fields) to be DEPLOYED first
-— otherwise every `upsert_profile` fails on an unknown field.
+REQUIRES the schema changes (the indexed fields, `username` field removed) to be
+DEPLOYED first — otherwise every `upsert_profile` fails on an unknown field.
 
 It walks kind-0 newest→oldest by `until` cursor, de-duplicates by pubkey within
 the run (first/newest wins; kind-0 is replaceable so strfry should already keep

--- a/scripts/search_compare.sh
+++ b/scripts/search_compare.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run the SAME query through the HTTP API and the NIP-50 relay and print the two
+# ranked lists side by side, flagging where they diverge.
+#
+# Both paths share app.core.vespa.search, so with the default observer and a
+# plain query they should match exactly. Divergence almost always means the
+# NIP-50 side resolved a different observer (an `observer:` token in the search
+# string, or a cold-start observer with no scores) or a sort:/filter: token.
+#
+# Usage:   ./search_compare.sh "<query>" [limit]
+# Env:     BRAINSTORM_HTTP, BRAINSTORM_WS  (default: staging)
+#
+# Note: pass extra NIP-50 tokens by quoting them into the query, e.g.
+#       ./search_compare.sh "cloud sort:rank:desc"
+#       The HTTP side treats unknown tokens as plain text (harmless).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUERY="${1:?usage: search_compare.sh \"<query>\" [limit]}"
+LIMIT="${2:-15}"
+
+http_tsv="$("$DIR/search_http.sh" "$QUERY" "$LIMIT" --tsv 2>/dev/null || true)"
+nip_tsv="$("$DIR/search_nip50.sh" "$QUERY" "$LIMIT" --tsv 2>/dev/null || true)"
+
+HTTP_TSV="$http_tsv" NIP_TSV="$nip_tsv" QUERY="$QUERY" python3 <<'PY'
+import os
+
+def parse(blob):
+    out = []
+    for line in blob.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            out.append((parts[1], parts[2]))  # (pubkey, name)
+    return out
+
+http = parse(os.environ.get("HTTP_TSV", ""))
+nip = parse(os.environ.get("NIP_TSV", ""))
+query = os.environ.get("QUERY", "")
+
+print()
+print(f"query: {query!r}    HTTP={len(http)} hits   NIP-50={len(nip)} hits")
+print()
+print(f"{chr(35):>2}  {'HTTP /search/byText':30}  {'NIP-50 relay':30}  match")
+print("-" * 74)
+n = max(len(http), len(nip))
+agree = True
+for i in range(n):
+    h = http[i] if i < len(http) else None
+    g = nip[i] if i < len(nip) else None
+    hn = h[1][:28] if h else "-"
+    gn = g[1][:28] if g else "-"
+    same = bool(h) and bool(g) and h[0] == g[0]
+    if not same:
+        agree = False
+    print(f"{i:2}  {hn:30}  {gn:30}  {'ok' if same else '<>'}")
+print("-" * 74)
+print("IDENTICAL order" if agree and http and nip else "ORDER DIFFERS (see <> rows above)")
+PY

--- a/scripts/search_http.sh
+++ b/scripts/search_http.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Test the HTTP profile search (GET /search/byText) from the command line.
+#
+# Prints results in Vespa rank order with the relevance score and the observer's
+# quality score (_quality_score) so you can see WHY they're ordered that way.
+# This is the anonymous / default-observer path (the same one the UI uses when
+# logged out). onlyRanked defaults to true (drops zero-trust hits); pass
+# --all to include them.
+#
+# Usage:   ./search_http.sh "<query>" [maxHits] [--all] [--tsv]
+# Env:     BRAINSTORM_HTTP  (default: staging server)
+#
+# Requires: curl, python3 (stdlib only).
+set -euo pipefail
+
+HTTP_BASE="${BRAINSTORM_HTTP:-https://brainstormserver-staging.nosfabrica.com}"
+
+TSV=0
+ONLY_RANKED=true
+ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --tsv) TSV=1 ;;
+    --all) ONLY_RANKED=false ;;
+    *) ARGS+=("$a") ;;
+  esac
+done
+QUERY="${ARGS[0]:?usage: search_http.sh \"<query>\" [maxHits] [--all] [--tsv]}"
+MAXHITS="${ARGS[1]:-15}"
+
+[ "$TSV" -eq 0 ] && echo "HTTP    $HTTP_BASE  text=$(printf '%q' "$QUERY")  onlyRanked=$ONLY_RANKED" >&2
+
+curl -s -G "$HTTP_BASE/search/byText" \
+  --data-urlencode "text=$QUERY" \
+  --data-urlencode "maxHits=$MAXHITS" \
+  --data-urlencode "onlyRanked=$ONLY_RANKED" \
+  | TSV="$TSV" python3 -c '
+import sys, os, json
+tsv = os.environ.get("TSV") == "1"
+
+def find_list(o):
+    if isinstance(o, list) and o and isinstance(o[0], dict):
+        return o
+    if isinstance(o, dict):
+        for v in o.values():
+            r = find_list(v)
+            if r:
+                return r
+    return None
+
+d = json.load(sys.stdin)
+res = find_list(d) or []
+for i, r in enumerate(res):
+    pk = r.get("pubkey", "")
+    nm = r.get("display_name") or r.get("name") or "?"
+    rel = r.get("_relevance")
+    qs = r.get("_quality_score")
+    if tsv:
+        print(f"{i}\t{pk}\t{nm}\t{rel}\t{qs}")
+    else:
+        rel_s = f"{rel:.1f}" if isinstance(rel, (int, float)) else str(rel)
+        print(f"{i:2}  {nm[:28]:28}  rel={rel_s:>9}  qs={qs}  {pk[:16]}")
+if not res and not tsv:
+    print("(no results)", file=sys.stderr)
+'

--- a/scripts/search_http.sh
+++ b/scripts/search_http.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Test the HTTP profile search (GET /search/byText) from the command line.
 #
-# Prints results in Vespa rank order with the relevance score and the observer's
-# quality score (_quality_score) so you can see WHY they're ordered that way.
+# Prints results in Vespa rank order with the relevance score, the match tier
+# (_match_tier: exact/prefix/1-typo/2-typo/gram — the §10 typo ladder), the
+# observer's verified-follower count (_followers) and quality score
+# (_quality_score) so you can see WHY they're ordered that way.
 # This is the anonymous / default-observer path (the same one the UI uses when
 # logged out). onlyRanked defaults to true (drops zero-trust hits); pass
 # --all to include them.
@@ -55,11 +57,14 @@ for i, r in enumerate(res):
     nm = r.get("display_name") or r.get("name") or "?"
     rel = r.get("_relevance")
     qs = r.get("_quality_score")
+    tier = r.get("_match_tier")
+    flw = r.get("_followers")
     if tsv:
-        print(f"{i}\t{pk}\t{nm}\t{rel}\t{qs}")
+        print(f"{i}\t{pk}\t{nm}\t{rel}\t{qs}\t{tier}\t{flw}")
     else:
         rel_s = f"{rel:.1f}" if isinstance(rel, (int, float)) else str(rel)
-        print(f"{i:2}  {nm[:28]:28}  rel={rel_s:>9}  qs={qs}  {pk[:16]}")
+        flw_s = f"{flw:.0f}" if isinstance(flw, (int, float)) else str(flw)
+        print(f"{i:2}  {nm[:26]:26}  tier={str(tier):7}  flw={flw_s:>6}  rel={rel_s:>9}  qs={qs}  {pk[:12]}")
 if not res and not tsv:
     print("(no results)", file=sys.stderr)
 '

--- a/scripts/search_nip50.sh
+++ b/scripts/search_nip50.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Test the NIP-50 search relay (wss .../relay) from the command line.
+#
+# Sends a NIP-01 REQ with a `search` filter, waits for EVENT frames, and prints
+# them in the order the relay returned them (i.e. Vespa rank order). The relay
+# only hands back kind-0 profile events, so we show display_name/name + pubkey.
+#
+# NIP-50 extension tokens go INSIDE the search string, so you can reproduce
+# per-observer / sort / filter behavior directly, e.g.:
+#   ./search_nip50.sh "cloud"
+#   ./search_nip50.sh "cloud observer:<64-hex-pubkey>"   # rank from that POV
+#   ./search_nip50.sh "cloud sort:rank:desc"             # pure trust order
+#   ./search_nip50.sh "cloud filter:rank:gte:50"         # drop low-trust hits
+#
+# Usage:   ./search_nip50.sh "<search string>" [limit] [--tsv]
+# Env:     BRAINSTORM_WS  (default: staging relay)
+#          NIP50_WAIT     seconds to keep the socket open (default 6)
+#
+# Requires: websocat, python3 (stdlib only).
+set -euo pipefail
+
+WS_URL="${BRAINSTORM_WS:-wss://brainstormserver-staging.nosfabrica.com/relay}"
+NIP50_WAIT="${NIP50_WAIT:-6}"
+
+TSV=0
+ARGS=()
+for a in "$@"; do
+  case "$a" in
+    --tsv) TSV=1 ;;
+    *) ARGS+=("$a") ;;
+  esac
+done
+QUERY="${ARGS[0]:?usage: search_nip50.sh \"<search string>\" [limit] [--tsv]}"
+LIMIT="${ARGS[1]:-15}"
+
+REQ=$(python3 -c 'import json,sys; print(json.dumps(["REQ","s1",{"kinds":[0],"search":sys.argv[1],"limit":int(sys.argv[2])}]))' "$QUERY" "$LIMIT")
+
+[ "$TSV" -eq 0 ] && echo "NIP-50  $WS_URL  search=$(printf '%q' "$QUERY")" >&2
+
+( printf '%s\n' "$REQ"; sleep "$NIP50_WAIT" ) \
+  | timeout "$((NIP50_WAIT + 6))" websocat -t "$WS_URL" 2>/dev/null \
+  | TSV="$TSV" python3 -c '
+import sys, os, json
+tsv = os.environ.get("TSV") == "1"
+i = 0
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        m = json.loads(line)
+    except ValueError:
+        continue
+    if not isinstance(m, list) or not m:
+        continue
+    if m[0] == "EVENT" and len(m) >= 3:
+        ev = m[2]
+        pk = ev.get("pubkey", "")
+        try:
+            c = json.loads(ev.get("content", "{}"))
+        except ValueError:
+            c = {}
+        nm = c.get("display_name") or c.get("name") or "?"
+        if tsv:
+            print(f"{i}\t{pk}\t{nm}")
+        else:
+            print(f"{i:2}  {nm[:28]:28}  {pk[:16]}")
+        i += 1
+    elif m[0] == "NOTICE" and not tsv:
+        print(f"NOTICE: {m[1] if len(m) > 1 else m}", file=sys.stderr)
+if i == 0 and not tsv:
+    print("(no results — check the query, the relay URL, or NIP50_WAIT)", file=sys.stderr)
+'

--- a/scripts/search_open_ranking.py
+++ b/scripts/search_open_ranking.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Test the Open Ranking search endpoint (ORE-05: POST /search/pubkeys).
+
+Returns pubkeys ranked by the observer's quality score. The observer is chosen
+(in priority order) by:
+
+  * a signed request  -> the signer's pubkey IS the observer (`--nsec` / `--sign`)
+  * `--pov <hex>`     -> that pubkey (sent unsigned; auth on this endpoint is optional)
+  * neither           -> the server's default observer
+
+That makes it easy to reproduce per-observer ranking differences (e.g. why a
+NIP-50 client showed a different order): just vary `--pov`.
+
+Usage:
+    # default observer, against staging:
+    python scripts/search_open_ranking.py --query cloud
+
+    # rank from a specific point of view (no signing needed):
+    python scripts/search_open_ranking.py --query cloud --pov <64-hex-pubkey>
+
+    # sign the request so the observer is the signer (fresh key by default):
+    python scripts/search_open_ranking.py --query cloud --sign
+    python scripts/search_open_ranking.py --query cloud --nsec nsec1...
+
+The ORE-05 response only carries {pubkey, rank}; this script best-effort
+annotates each pubkey with its profile name via GET /search/byText so the
+output is readable.
+
+Requires: requests, nostr-sdk (both in the server's poetry env).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+import time
+from urllib.parse import urlparse
+
+import requests
+from nostr_sdk import EventBuilder, Keys, Kind, Tag
+
+NWT_KIND = 27519
+
+
+def mint_nwt(keys: Keys, audience: str, ttl_seconds: int = 300) -> str:
+    """Sign a kind-27519 NWT and base64url-encode it for `Authorization: Nostr`."""
+    exp = int(time.time()) + ttl_seconds
+    event = (
+        EventBuilder(Kind(NWT_KIND), "open-ranking search test")
+        .tags([Tag.parse(["aud", audience]), Tag.parse(["exp", str(exp)])])
+        .sign_with_keys(keys)
+    )
+    return (
+        base64.urlsafe_b64encode(event.as_json().encode("utf-8"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def name_map(base_url: str, query: str) -> dict[str, str]:
+    """Best-effort pubkey -> display name, via the public byText endpoint."""
+    try:
+        r = requests.get(
+            base_url.rstrip("/") + "/search/byText",
+            params={"text": query, "maxHits": 400, "onlyRanked": "false"},
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except Exception:
+        return {}
+
+    def find_list(o):
+        if isinstance(o, list) and o and isinstance(o[0], dict):
+            return o
+        if isinstance(o, dict):
+            for v in o.values():
+                got = find_list(v)
+                if got:
+                    return got
+        return None
+
+    out: dict[str, str] = {}
+    for r in find_list(data) or []:
+        pk = r.get("pubkey")
+        if isinstance(pk, str):
+            out[pk] = r.get("display_name") or r.get("name") or "?"
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--base-url", default="https://brainstormserver-staging.nosfabrica.com"
+    )
+    p.add_argument("--query", required=True, help="free-text search query")
+    p.add_argument("--pov", default=None, help="observer pubkey (hex) to rank from")
+    p.add_argument(
+        "--algo",
+        default=None,
+        help=(
+            "ORE-05 algorithm id. pov only applies to the personalized algorithm "
+            "(name-trust-pov), so --pov auto-selects it unless --algo is given."
+        ),
+    )
+    p.add_argument("--limit", type=int, default=15)
+    p.add_argument(
+        "--nsec", default=None, help="sign with this key (bech32/hex); implies --sign"
+    )
+    p.add_argument(
+        "--sign",
+        action="store_true",
+        help="sign the request so the observer = signer (generates a key if no --nsec)",
+    )
+    p.add_argument("--audience", default=None, help="aud claim; default = host of base-url")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+
+    body: dict = {"query": args.query, "limit": args.limit}
+    headers = {"content-type": "application/json"}
+    observer_desc = "server default"
+
+    # pov is honored only by a pov-based algorithm; default to the personalized
+    # one when --pov is given (the default name-trust algorithm ignores pov).
+    algo = args.algo or ("name-trust-pov" if args.pov else None)
+    if algo:
+        body["algorithm"] = algo
+
+    if args.nsec or args.sign:
+        keys = Keys.parse(args.nsec) if args.nsec else Keys.generate()
+        audience = args.audience or urlparse(args.base_url).hostname
+        headers["Authorization"] = f"Nostr {mint_nwt(keys, audience)}"
+        observer_desc = f"signer {keys.public_key().to_hex()[:16]}…"
+    elif args.pov:
+        body["pov"] = args.pov
+        observer_desc = f"pov {args.pov[:16]}…"
+
+    url = args.base_url.rstrip("/") + "/search/pubkeys"
+    print(f"POST {url}")
+    print(f"query    : {args.query!r}")
+    print(f"observer : {observer_desc}")
+    print("-" * 72)
+
+    resp = requests.post(url, headers=headers, data=json.dumps(body), timeout=20)
+    if not (200 <= resp.status_code < 300):
+        print(f"[FAIL] {resp.status_code} {resp.headers.get('x-reason', '')}")
+        print(resp.text[:800])
+        return 1
+
+    results = resp.json().get("results", [])
+    names = name_map(args.base_url, args.query)
+    for i, r in enumerate(results):
+        pk = r.get("pubkey", "")
+        rank = r.get("rank")
+        nm = names.get(pk, "?")
+        print(f"{i:2}  {str(nm)[:28]:28}  rank={rank}  {pk[:16]}")
+    if not results:
+        print("(no results)")
+    if args.verbose:
+        print("-" * 72)
+        print(json.dumps(resp.json(), indent=2)[:1200])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/search_open_ranking.sh
+++ b/scripts/search_open_ranking.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Test the Open Ranking search endpoint (ORE-05: POST /search/pubkeys) with NO
+# auth. ORE-05 auth is optional (optional_nwt_signer) and currently turned off,
+# so a plain unsigned POST works — handy for quick testing.
+#
+# To rank from a specific observer, pass --pov <hex>. NOTE: pov only takes
+# effect with the *personalized* algorithm (name-trust-pov); the default
+# algorithm (name-trust) is global and ignores pov per ORE-01. This script
+# auto-selects name-trust-pov whenever you pass --pov (override with --algo).
+# (To rank AS a signed observer you need the Python version,
+# search_open_ranking.py, which signs the NWT.)
+#
+# The ORE-05 response is just {pubkey, rank}; this best-effort annotates each
+# pubkey with its profile name via GET /search/byText so the output is readable.
+#
+# Usage:   ./search_open_ranking.sh "<query>" [limit] [--pov <hex>] [--algo <id>] [--tsv]
+# Env:     BRAINSTORM_HTTP  (default: staging server)
+#
+# Requires: curl, python3 (stdlib only).
+set -euo pipefail
+
+HTTP_BASE="${BRAINSTORM_HTTP:-https://brainstormserver-staging.nosfabrica.com}"
+
+TSV=0
+POV=""
+ALGO=""
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tsv) TSV=1 ;;
+    --pov) shift; POV="${1:?--pov needs a hex pubkey}" ;;
+    --algo) shift; ALGO="${1:?--algo needs an algorithm id}" ;;
+    *) ARGS+=("$1") ;;
+  esac
+  shift
+done
+QUERY="${ARGS[0]:?usage: search_open_ranking.sh \"<query>\" [limit] [--pov <hex>] [--algo <id>] [--tsv]}"
+LIMIT="${ARGS[1]:-15}"
+
+# pov is honored only by a pov-based algorithm; default to the personalized one.
+[ -n "$POV" ] && [ -z "$ALGO" ] && ALGO="name-trust-pov"
+
+BODY=$(python3 -c 'import json,sys; b={"query":sys.argv[1],"limit":int(sys.argv[2])}; \
+pov,algo=sys.argv[3],sys.argv[4]; \
+b.update({"pov":pov} if pov else {}); b.update({"algorithm":algo} if algo else {}); \
+print(json.dumps(b))' "$QUERY" "$LIMIT" "$POV" "$ALGO")
+
+[ "$TSV" -eq 0 ] && echo "ORE-05  $HTTP_BASE/search/pubkeys  query=$(printf '%q' "$QUERY")  pov=${POV:-<default>}  algo=${ALGO:-<default>}" >&2
+
+# POST the search; capture body + HTTP status (last line).
+resp=$(curl -s -w $'\n%{http_code}' -X POST "$HTTP_BASE/search/pubkeys" \
+  -H 'content-type: application/json' -d "$BODY")
+code="${resp##*$'\n'}"
+results_json="${resp%$'\n'*}"
+
+# Stash the (potentially large) JSON blobs in temp files — passing full profile
+# payloads through env vars overflows ARG_MAX ("Argument list too long").
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+printf '%s' "$results_json" > "$tmp/results.json"
+
+# Best-effort name lookup (public, no auth).
+curl -s -G "$HTTP_BASE/search/byText" \
+  --data-urlencode "text=$QUERY" --data-urlencode "maxHits=400" \
+  --data-urlencode "onlyRanked=false" > "$tmp/names.json" 2>/dev/null || echo '{}' > "$tmp/names.json"
+
+CODE="$code" RESULTS_FILE="$tmp/results.json" NAMES_FILE="$tmp/names.json" TSV="$TSV" python3 <<'PY'
+import os, json, sys
+
+tsv = os.environ.get("TSV") == "1"
+code = os.environ.get("CODE", "")
+results_text = open(os.environ["RESULTS_FILE"]).read()
+if not code.startswith("2"):
+    print(f"[FAIL] HTTP {code}", file=sys.stderr)
+    print(results_text[:800], file=sys.stderr)
+    sys.exit(1)
+
+def find_list(o):
+    if isinstance(o, list) and o and isinstance(o[0], dict):
+        return o
+    if isinstance(o, dict):
+        for v in o.values():
+            got = find_list(v)
+            if got:
+                return got
+    return None
+
+# Build pubkey -> name from the byText response.
+names = {}
+try:
+    with open(os.environ["NAMES_FILE"]) as fh:
+        for r in find_list(json.load(fh)) or []:
+            pk = r.get("pubkey")
+            if isinstance(pk, str):
+                names[pk] = r.get("display_name") or r.get("name") or "?"
+except Exception:
+    pass
+
+results = json.loads(results_text).get("results", [])
+for i, r in enumerate(results):
+    pk = r.get("pubkey", "")
+    rank = r.get("rank")
+    nm = names.get(pk, "?")
+    if tsv:
+        print(f"{i}\t{pk}\t{nm}\t{rank}")
+    else:
+        print(f"{i:2}  {str(nm)[:28]:28}  rank={rank}  {pk[:16]}")
+if not results and not tsv:
+    print("(no results)", file=sys.stderr)
+PY

--- a/scripts/smoke_open_ranking.py
+++ b/scripts/smoke_open_ranking.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Smoke-test the Open Ranking endpoints against a live deployment.
+
+Mints a fresh NWT (signed kind-27519 event) on every request and exercises
+every endpoint.
+
+Usage:
+    # Default: hit staging on arrowhead, generate a one-off signing key.
+    python scripts/smoke_open_ranking.py
+
+    # Target a different host:
+    python scripts/smoke_open_ranking.py --base-url https://api.example.com
+
+    # Use a specific nsec (bech32 or hex):
+    python scripts/smoke_open_ranking.py --nsec nsec1...
+
+    # Probe just one endpoint:
+    python scripts/smoke_open_ranking.py --only stats
+
+Requires: requests, nostr-sdk (both already in the server's poetry env).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+import time
+from urllib.parse import urlparse
+
+import requests
+from nostr_sdk import EventBuilder, Keys, Kind, Tag
+
+
+NWT_KIND = 27519
+
+
+def mint_nwt(keys: Keys, audience: str, ttl_seconds: int = 300) -> str:
+    """Sign a kind-27519 event with aud + exp claims, return the
+    base64url-no-padding-encoded JSON ready to drop into an Authorization
+    header as `Nostr <token>`.
+    """
+    exp = int(time.time()) + ttl_seconds
+    event = (
+        EventBuilder(Kind(NWT_KIND), "open-ranking smoke test")
+        .tags([Tag.parse(["aud", audience]), Tag.parse(["exp", str(exp)])])
+        .sign_with_keys(keys)
+    )
+    return (
+        base64.urlsafe_b64encode(event.as_json().encode("utf-8"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def call(
+    base_url: str,
+    path: str,
+    *,
+    method: str = "POST",
+    body: dict | None = None,
+    keys: Keys | None = None,
+    audience: str | None = None,
+    timeout: float = 15.0,
+) -> requests.Response:
+    headers = {"content-type": "application/json"}
+    if keys is not None and audience is not None:
+        headers["Authorization"] = f"Nostr {mint_nwt(keys, audience)}"
+    url = base_url.rstrip("/") + path
+    return requests.request(
+        method,
+        url,
+        headers=headers,
+        data=json.dumps(body) if body is not None else None,
+        timeout=timeout,
+    )
+
+
+def show(name: str, resp: requests.Response, verbose: bool) -> bool:
+    ok = 200 <= resp.status_code < 300
+    icon = "OK  " if ok else "FAIL"
+    reason = resp.headers.get("x-reason", "")
+    print(f"[{icon}] {name:<28} {resp.status_code} {reason}".rstrip())
+    if not ok or verbose:
+        body = resp.text
+        if len(body) > 600:
+            body = body[:600] + "..."
+        print(f"       body: {body}")
+    return ok
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--base-url",
+        default="https://brainstormserver-staging.nosfabrica.com",
+    )
+    p.add_argument(
+        "--audience",
+        default=None,
+        help="aud claim to sign. Default: hostname of --base-url.",
+    )
+    p.add_argument(
+        "--nsec",
+        default=None,
+        help="Signing key (bech32 nsec or hex). Default: generate fresh.",
+    )
+    p.add_argument(
+        "--target-pubkey",
+        default="be7bf5de068c1d842ed34a7c270507ec940f5ea51671cfd062a95e9d09420d0a",
+        help="Pubkey to query about. Default: the periodic-graperank pubkey.",
+    )
+    p.add_argument(
+        "--only",
+        choices=["wellknown", "stats", "rank", "search", "followers", "muters", "noauth"],
+        default=None,
+    )
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+
+    audience = args.audience or urlparse(args.base_url).hostname
+    keys = Keys.parse(args.nsec) if args.nsec else Keys.generate()
+    target = args.target_pubkey
+
+    print(f"base_url : {args.base_url}")
+    print(f"audience : {audience}")
+    print(f"signer   : {keys.public_key().to_hex()}")
+    print(f"target   : {target}")
+    print("-" * 72)
+
+    pass_count = 0
+    fail_count = 0
+
+    def record(ok: bool) -> None:
+        nonlocal pass_count, fail_count
+        pass_count += int(ok)
+        fail_count += int(not ok)
+
+    suite = args.only or "all"
+
+    if suite in ("all", "wellknown"):
+        r = call(args.base_url, "/.well-known/open-ranking.json", method="GET")
+        record(show("GET  /.well-known", r, args.verbose))
+
+    # Negative control: same endpoint without auth must be 401.
+    if suite in ("all", "noauth"):
+        r = call(args.base_url, "/stats/pubkey", body={"pubkey": target})
+        ok = r.status_code == 401
+        print(
+            f"[{'OK  ' if ok else 'FAIL'}] no-auth control            "
+            f"{r.status_code} (expected 401) "
+            f"{r.headers.get('x-reason', '')}".rstrip()
+        )
+        record(ok)
+
+    if suite in ("all", "stats"):
+        r = call(
+            args.base_url, "/stats/pubkey",
+            body={"pubkey": target}, keys=keys, audience=audience,
+        )
+        record(show("POST /stats/pubkey", r, args.verbose))
+
+    if suite in ("all", "rank"):
+        r = call(
+            args.base_url, "/rank/pubkeys",
+            body={"pubkeys": [target]}, keys=keys, audience=audience,
+        )
+        record(show("POST /rank/pubkeys", r, args.verbose))
+
+    if suite in ("all", "search"):
+        r = call(
+            args.base_url, "/search/pubkeys",
+            body={"query": "jack"}, keys=keys, audience=audience,
+        )
+        record(show("POST /search/pubkeys", r, args.verbose))
+
+    if suite in ("all", "followers"):
+        r = call(
+            args.base_url, "/followers",
+            body={"pubkey": target, "limit": 5}, keys=keys, audience=audience,
+        )
+        record(show("POST /followers", r, args.verbose))
+
+    if suite in ("all", "muters"):
+        r = call(
+            args.base_url, "/muters",
+            body={"pubkey": target, "limit": 5}, keys=keys, audience=audience,
+        )
+        record(show("POST /muters", r, args.verbose))
+
+    print("-" * 72)
+    print(f"summary  : {pass_count} passed, {fail_count} failed")
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/trigger_graperank_all.py
+++ b/scripts/trigger_graperank_all.py
@@ -1,0 +1,194 @@
+"""Bulk-trigger GrapeRank for every observer — paced, resumable, with status.
+
+Re-runs GrapeRank for ALL observer perspectives (rows in `brainstorm_nsec`) so
+each observer's Vespa tensors (`quality_scores` + the new `follower_counts`) get
+repopulated — e.g. the follower-count backfill in docs/search-vs-tapestry.md
+§8/§9. GrapeRank is expensive per observer, so enqueues are RATE-LIMITED.
+
+"Done" is read from the `brainstorm_request` table, so there's no fragile
+bookkeeping: for a campaign that started at time T, an observer is
+  * triggered  → it has a `graperank` request created at/after T, and
+  * completed  → that request reached status `success`.
+The campaign start T is stored in a small state file so re-running the script
+RESUMES (skips already-triggered observers) without re-enqueuing. The DB is the
+source of truth; the state file only remembers when the campaign began.
+
+Run from a brainstorm-server pod / the container (needs a populated `.env`):
+
+    # How many observers, how many done, how many pending (no writes):
+    python -m scripts.trigger_graperank_all --status
+
+    # Preview the next batch without enqueuing:
+    python -m scripts.trigger_graperank_all --dry-run --limit 50
+
+    # Enqueue up to 200 observers this run at 30/min, then resume later by
+    # just running again (already-triggered observers are skipped):
+    python -m scripts.trigger_graperank_all --rate 30 --limit 200
+    python -m scripts.trigger_graperank_all --rate 30
+
+Flags:
+    --rate N        observers to ENQUEUE per minute (default 20). Tune to the
+                    graperank worker's throughput so the queue doesn't back up.
+    --limit N       max observers to enqueue this invocation (default: no cap).
+    --since ISO     override the campaign-start cutoff (else read/written to the
+                    state file). Pass a NEW value to start a fresh campaign.
+    --state-file P  campaign-state json (default ./graperank_backfill_state.json).
+    --status        print progress and exit (no enqueue).
+    --dry-run       list what WOULD be enqueued; don't enqueue.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select  # noqa: E402
+
+from app.core.database import db_session  # noqa: E402
+from app.db_models import (  # noqa: E402
+    BrainstormNsec,
+    BrainstormRequest,
+    BrainstormRequestStatus,
+)
+from app.services.brainstorm_request_service import (  # noqa: E402
+    create_brainstorm_request,
+)
+
+_GRAPERANK = "graperank"
+_SUCCESS = BrainstormRequestStatus.SUCCESS.value
+_DEFAULT_STATE = "graperank_backfill_state.json"
+
+
+def _now() -> datetime:
+    # Naive UTC to match the `DateTime` (tz-naive) created_at columns and avoid
+    # aware-vs-naive comparison errors in the WHERE clause.
+    return datetime.utcnow()
+
+
+def _resolve_cutoff(args) -> datetime:
+    """Campaign-start cutoff: --since wins; else read the state file; else stamp
+    'now' and persist it so future runs resume against the same campaign."""
+    if args.since:
+        return datetime.fromisoformat(args.since)
+
+    state_path = Path(args.state_file)
+    if state_path.exists():
+        data = json.loads(state_path.read_text())
+        return datetime.fromisoformat(data["campaign_started_at"])
+
+    started = _now()
+    if not args.status and not args.dry_run:
+        state_path.write_text(
+            json.dumps({"campaign_started_at": started.isoformat()}, indent=2)
+        )
+        print(f"[campaign] started at {started.isoformat()} (saved to {state_path})")
+    return started
+
+
+async def _load_state(cutoff: datetime):
+    """Return (all_observers, triggered_set, completed_set) for this campaign."""
+    async with db_session() as db:
+        observers = (
+            (await db.execute(select(BrainstormNsec.pubkey))).scalars().all()
+        )
+        rows = (
+            await db.execute(
+                select(BrainstormRequest.pubkey, BrainstormRequest.status).where(
+                    BrainstormRequest.algorithm == _GRAPERANK,
+                    BrainstormRequest.created_at >= cutoff,
+                )
+            )
+        ).all()
+
+    triggered: set[str] = set()
+    completed: set[str] = set()
+    for pubkey, status in rows:
+        if not pubkey:
+            continue
+        triggered.add(pubkey)
+        if status == _SUCCESS:
+            completed.add(pubkey)
+    return sorted(set(observers)), triggered, completed
+
+
+def _print_status(observers, triggered, completed, cutoff) -> None:
+    total = len(observers)
+    obs = set(observers)
+    n_trig = len(triggered & obs)
+    n_done = len(completed & obs)
+    n_inflight = n_trig - n_done
+    n_pending = total - n_trig
+    print(f"campaign start : {cutoff.isoformat()}")
+    print(f"observers      : {total}")
+    print(f"  completed    : {n_done}  (graperank success since campaign start)")
+    print(f"  in-flight    : {n_inflight}  (triggered, not yet success)")
+    print(f"  pending      : {n_pending}  (not yet triggered)")
+
+
+async def _trigger_one(pubkey: str) -> None:
+    async with db_session() as db:
+        await create_brainstorm_request(
+            db=db,
+            algorithm=_GRAPERANK,
+            parameters=pubkey,
+            pubkey=pubkey,
+            nsec_exists=True,  # observers in brainstorm_nsec already have one
+        )
+
+
+async def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--rate", type=float, default=20.0, help="enqueues per minute")
+    p.add_argument("--limit", type=int, default=None, help="max to enqueue this run")
+    p.add_argument("--since", default=None, help="ISO cutoff; overrides state file")
+    p.add_argument("--state-file", default=_DEFAULT_STATE)
+    p.add_argument("--status", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    cutoff = _resolve_cutoff(args)
+    observers, triggered, completed = await _load_state(cutoff)
+
+    if args.status:
+        _print_status(observers, triggered, completed, cutoff)
+        return 0
+
+    to_trigger = [o for o in observers if o not in triggered]
+    if args.limit is not None:
+        to_trigger = to_trigger[: args.limit]
+
+    _print_status(observers, triggered, completed, cutoff)
+    print(f"to enqueue now : {len(to_trigger)}  (rate={args.rate}/min)")
+
+    if args.dry_run:
+        for o in to_trigger[:20]:
+            print(f"  would trigger {o}")
+        if len(to_trigger) > 20:
+            print(f"  ... and {len(to_trigger) - 20} more")
+        return 0
+
+    delay = 60.0 / args.rate if args.rate > 0 else 0.0
+    enqueued = 0
+    for o in to_trigger:
+        try:
+            await _trigger_one(o)
+            enqueued += 1
+            if enqueued % 25 == 0:
+                print(f"  enqueued {enqueued}/{len(to_trigger)}")
+        except Exception as exc:  # noqa: BLE001 — keep going; resume covers gaps
+            print(f"  FAILED to trigger {o}: {exc!r}", file=sys.stderr)
+        if delay:
+            await asyncio.sleep(delay)
+
+    print(f"done: enqueued {enqueued} graperank request(s). "
+          f"Re-run to continue, or --status to watch completion.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,30 @@
-"""Shared fixtures for the fast (mocked) test suite.
+"""Shared fixtures + settings bootstrap for the test suites.
 
-The FastAPI app is imported and driven via ``TestClient`` *without* entering it
-as a context manager, so the lifespan (Neo4j connectivity check + background
-consumers) never runs and no real services are needed. Auth is satisfied by
-overriding the ``verify_token`` dependency to inject a caller pubkey, and the
-Neo4j/Redis side-effects are mocked per-test.
+Two suites share this tree:
+
+- The fast, mocked suite (``tests/test_*.py``, ``tests/integration/``) drives the
+  full FastAPI app (``app.api:app``) through ``TestClient`` *without* entering it
+  as a context manager, so the lifespan (Neo4j check + background consumers)
+  never runs and no real services are needed. Auth is satisfied by overriding
+  ``verify_token``; Neo4j/Redis side-effects are mocked per-test. Fixtures:
+  ``caller``, ``client``, ``mock_rate_limit``, ``mock_kind3_write``.
+
+- The Open Ranking E2E suite (``tests/open_ranking/``) boots a *minimal* app that
+  mounts only the Open Ranking router; its ``app``/``client``/``auth_headers``
+  fixtures live in ``tests/open_ranking/conftest.py``. It reuses the NWT helpers
+  (``make_nwt``) defined here.
+
+Settings env is populated here, BEFORE any ``app.*`` import, because
+``app.core.config.settings`` is constructed at import time.
 """
 
 import json
 import os
+import sys
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -54,9 +68,19 @@ _DUMMY_ENV = {
     "FRONTEND_URL": "http://localhost:3000",
     "PUBLIC_BASE_URL": "http://localhost:8080",
     "VESPA_URL": "http://localhost:8080",
+    # Default observer perspective for the Open Ranking endpoints (their global
+    # algorithms resolve the observer to this pubkey).
+    "PERIODIC_GRAPERANK_PUBKEY": (
+        "be7bf5de068c1d842ed34a7c270507ec940f5ea51671cfd062a95e9d09420d0a"
+    ),
 }
 for _key, _value in _DUMMY_ENV.items():
     os.environ.setdefault(_key, _value)
+
+# Ensure the project root is importable when pytest is invoked from elsewhere.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from fastapi import Request
 from fastapi.testclient import TestClient
@@ -67,6 +91,9 @@ from app.utils.api_validators import verify_token
 from app.utils.auth.auth_models import JWTData
 
 
+# ---------------------------------------------------------------------------
+# Event-building helpers (importable: `from tests.conftest import ...`)
+# ---------------------------------------------------------------------------
 def signed_event(
     keys: Keys, kind: int, follow_pubkeys: list[str] | None = None
 ) -> dict:
@@ -80,6 +107,62 @@ def signed_kind3(keys: Keys, follow_pubkeys: list[str]) -> dict:
     return signed_event(keys, 3, follow_pubkeys)
 
 
+# ---------------------------------------------------------------------------
+# NWT helpers — shared with the Open Ranking suite
+# ---------------------------------------------------------------------------
+_SENTINEL_OMIT = object()
+
+# Audience the test app expects. Matches the hostname of PUBLIC_BASE_URL set in
+# _DUMMY_ENV above (the NWT verifier derives `aud` from that).
+TEST_AUD = "localhost"
+
+
+def make_nwt(
+    *,
+    keys: Keys | None = None,
+    aud: str | list[str] | None = TEST_AUD,
+    exp=_SENTINEL_OMIT,
+    nbf: int | None = None,
+    iat: int | None = None,
+    kind: int = 27519,
+) -> tuple[str, str]:
+    """Build a signed NWT, return (base64url_token, signer_hex_pubkey).
+
+    - `aud` may be a string (single tag), a list (one tag per element), or
+      None (no aud tag).
+    - `exp` defaults to ~1 hour in the future. Pass `None` to OMIT it.
+    """
+    import base64
+
+    keys = keys or Keys.generate()
+    tags: list[Tag] = []
+
+    if aud is not None:
+        aud_list = [aud] if isinstance(aud, str) else aud
+        for a in aud_list:
+            tags.append(Tag.parse(["aud", a]))
+
+    if exp is _SENTINEL_OMIT:
+        exp = int(time.time()) + 3600
+    if exp is not None:
+        tags.append(Tag.parse(["exp", str(exp)]))
+    if nbf is not None:
+        tags.append(Tag.parse(["nbf", str(nbf)]))
+    if iat is not None:
+        tags.append(Tag.parse(["iat", str(iat)]))
+
+    event = EventBuilder(Kind(kind), "").tags(tags).sign_with_keys(keys)
+    token = (
+        base64.urlsafe_b64encode(event.as_json().encode("utf-8"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    return token, keys.public_key().to_hex()
+
+
+# ---------------------------------------------------------------------------
+# Fast-suite fixtures (full app.api:app + mocked side-effects)
+# ---------------------------------------------------------------------------
 class _Caller:
     """The authenticated caller; holds the keypair whose pubkey the JWT carries."""
 

--- a/tests/open_ranking/conftest.py
+++ b/tests/open_ranking/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures for the Open Ranking E2E tests.
+
+Boots a real-but-minimal FastAPI app that mounts ONLY the Open Ranking router
+and exercises it through `TestClient` (real ASGI dispatch, real Pydantic
+validation, real exception handlers, real CORS). Keeping the app minimal makes
+these tests independent of the full brainstorm_server lifespan / background
+tasks. External data sources (Neo4j, Redis, Vespa) are stubbed per-test.
+
+Settings env and the NWT helpers (`make_nwt`) are bootstrapped in the parent
+`tests/conftest.py`.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_nwt
+
+
+# ---------------------------------------------------------------------------
+# App factory: only mounts the Open Ranking router.
+# ---------------------------------------------------------------------------
+def _build_app() -> FastAPI:
+    from app.routers.open_ranking.router import router as open_ranking_router
+
+    app = FastAPI()
+    # Mirror the CORS posture of the production app so OPTIONS preflight tests
+    # behave the same here.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(open_ranking_router)
+    return app
+
+
+@pytest.fixture()
+def app() -> FastAPI:
+    return _build_app()
+
+
+@pytest.fixture()
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture()
+def auth_headers() -> dict[str, str]:
+    """A fresh, valid NWT for every test that needs an authenticated call. The
+    signing key is regenerated per-test so token reuse across cases can't
+    accidentally pass.
+    """
+    token, _pk = make_nwt()
+    return {"Authorization": f"Nostr {token}"}

--- a/tests/open_ranking/test_open_ranking_e2e.py
+++ b/tests/open_ranking/test_open_ranking_e2e.py
@@ -1,0 +1,462 @@
+"""End-to-end tests for the Open Ranking endpoints.
+
+These boot a FastAPI app, route a real HTTP request through ASGI, and verify
+the response per the ORE specs. The Neo4j / Redis / Vespa boundaries are
+patched at import sites in the open_ranking router modules so the suite is
+deterministic and infra-free.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from nostr_sdk import Keys
+
+from tests.conftest import make_nwt
+
+
+VALID_PUBKEY_1 = "a" * 64
+VALID_PUBKEY_2 = "b" * 64
+VALID_PUBKEY_3 = "c" * 64
+POV_PUBKEY = "d" * 64
+INVALID_PUBKEY = "not-a-valid-pubkey"
+
+
+# ===========================================================================
+# ORE-01: Capability document
+# ===========================================================================
+class TestCapabilityDocument:
+    def test_well_known_returns_capability_doc(self, client):
+        r = client.get("/.well-known/open-ranking.json")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("application/json")
+        body = r.json()
+        # All implemented endpoints MUST be advertised.
+        for path in (
+            "/stats/pubkey",
+            "/rank/pubkeys",
+            "/search/pubkeys",
+            "/followers",
+            "/muters",
+        ):
+            assert path in body, f"capability doc missing {path}"
+            assert isinstance(body[path], list) and body[path]
+            for algo in body[path]:
+                assert "id" in algo
+
+    def test_capability_doc_cors_header_present(self, client):
+        r = client.get(
+            "/.well-known/open-ranking.json",
+            headers={"Origin": "https://nostr.example"},
+        )
+        assert r.headers.get("access-control-allow-origin") == "*"
+
+    def test_options_preflight_on_stats(self, client):
+        r = client.options(
+            "/stats/pubkey",
+            headers={
+                "Origin": "https://nostr.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+        # Per ORE-00, providers MUST handle OPTIONS preflight with 200.
+        assert r.status_code == 200
+        assert r.headers.get("access-control-allow-origin") == "*"
+
+
+# ===========================================================================
+# ORE-02: /stats/pubkey
+# ===========================================================================
+def _fake_overview(influence: float | None = 0.42):
+    from app.schemas.schemas import UserConnectionCounts, UserOverviewData
+
+    return UserOverviewData(
+        pubkey=VALID_PUBKEY_1,
+        influence=influence,
+        flagged_by_observer=False,
+        flagged_count=0,
+        counts=UserConnectionCounts(
+            followed_by=10, following=20, muted_by=1, muting=2, reported_by=3, reporting=4,
+        ),
+    )
+
+
+class TestStatsPubkey:
+    def test_happy_path_global_algorithm(self, client, auth_headers):
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(0.42)),
+        ):
+            r = client.post(
+                "/stats/pubkey", json={"pubkey": VALID_PUBKEY_1}, headers=auth_headers,
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["pubkey"] == VALID_PUBKEY_1
+        assert body["rank"] == pytest.approx(0.42)
+        assert body["follows"] == 20
+        assert body["followers"] == 10
+        assert body["mutes"] == 2
+        assert body["muters"] == 1
+        assert body["reports"] == 4
+        assert body["reporters"] == 3
+        assert isinstance(body["ttl"], int) and body["ttl"] > 0
+
+    def test_null_influence_becomes_zero_rank(self, client, auth_headers):
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(None)),
+        ):
+            r = client.post(
+                "/stats/pubkey", json={"pubkey": VALID_PUBKEY_1}, headers=auth_headers,
+            )
+        assert r.status_code == 200
+        assert r.json()["rank"] == 0.0
+
+    def test_invalid_pubkey_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/stats/pubkey", json={"pubkey": INVALID_PUBKEY}, headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+    def test_pov_required_when_algorithm_is_personalized(self, client, auth_headers):
+        # graperank-pov requires a pov pubkey per the capability doc.
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1, "algorithm": "graperank-pov"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 422
+        assert "pov" in r.text.lower()
+
+    def test_unsupported_algorithm_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1, "algorithm": "made-up-algo"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+    def test_personalized_algorithm_uses_pov_as_observer(self, client, auth_headers):
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["pubkey"] = pubkey
+            observed["observer"] = observer
+            return _fake_overview(0.9)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={
+                    "pubkey": VALID_PUBKEY_1,
+                    "algorithm": "graperank-pov",
+                    "pov": POV_PUBKEY,
+                },
+                headers=auth_headers,
+            )
+        assert r.status_code == 200
+        assert observed == {"pubkey": VALID_PUBKEY_1, "observer": POV_PUBKEY}
+
+
+# ===========================================================================
+# ORE-03: /rank/pubkeys
+# ===========================================================================
+class TestRankPubkeys:
+    def test_happy_path_default_limit_and_sorting(self, client, auth_headers):
+        async def fake_batch(session, pubkeys, observer):
+            return {
+                VALID_PUBKEY_1: 0.1,
+                VALID_PUBKEY_2: 0.9,
+                VALID_PUBKEY_3: None,  # unknown -> coerced to 0.0
+            }
+
+        with patch(
+            "app.routers.open_ranking.rank.batch_influence_for_pubkeys",
+            new=fake_batch,
+        ), patch("app.routers.open_ranking.rank.neo4j_driver"):
+            r = client.post(
+                "/rank/pubkeys",
+                json={"pubkeys": [VALID_PUBKEY_1, VALID_PUBKEY_2, VALID_PUBKEY_3]},
+                headers=auth_headers,
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        results = body["results"]
+        # Length = number of input pubkeys when no limit given.
+        assert len(results) == 3
+        # Sorted by rank DESC.
+        ranks = [r["rank"] for r in results]
+        assert ranks == sorted(ranks, reverse=True)
+        # Unknown pubkey is present and ranked 0.
+        unknown = next(x for x in results if x["pubkey"] == VALID_PUBKEY_3)
+        assert unknown["rank"] == 0.0
+
+    def test_limit_clamped_to_requested(self, client, auth_headers):
+        async def fake_batch(session, pubkeys, observer):
+            return {pk: 0.5 for pk in pubkeys}
+
+        with patch(
+            "app.routers.open_ranking.rank.batch_influence_for_pubkeys",
+            new=fake_batch,
+        ), patch("app.routers.open_ranking.rank.neo4j_driver"):
+            r = client.post(
+                "/rank/pubkeys",
+                json={
+                    "pubkeys": [VALID_PUBKEY_1, VALID_PUBKEY_2, VALID_PUBKEY_3],
+                    "limit": 2,
+                },
+                headers=auth_headers,
+            )
+        assert r.status_code == 200
+        assert len(r.json()["results"]) == 2
+
+    def test_empty_pubkeys_returns_422(self, client, auth_headers):
+        r = client.post("/rank/pubkeys", json={"pubkeys": []}, headers=auth_headers)
+        assert r.status_code == 422
+
+    def test_invalid_limit_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/rank/pubkeys",
+            json={"pubkeys": [VALID_PUBKEY_1], "limit": 0},
+            headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+    def test_oversize_batch_returns_413(self, client, auth_headers):
+        big = [f"{i:064x}" for i in range(1001)]
+        r = client.post("/rank/pubkeys", json={"pubkeys": big}, headers=auth_headers)
+        assert r.status_code == 413
+
+    def test_bad_pubkey_in_list_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/rank/pubkeys",
+            json={"pubkeys": [VALID_PUBKEY_1, INVALID_PUBKEY]},
+            headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+
+# ===========================================================================
+# ORE-05: /search/pubkeys
+# ===========================================================================
+class TestSearchPubkeys:
+    def test_happy_path(self, client, auth_headers):
+        async def fake_search(query_text, user_pubkey, hits, include_zero_score_results):
+            return [
+                {"pubkey": VALID_PUBKEY_1, "_quality_score": 0.91},
+                {"pubkey": VALID_PUBKEY_2, "_quality_score": 0.45},
+            ]
+
+        with patch("app.routers.open_ranking.search.vespa_search", new=fake_search):
+            r = client.post(
+                "/search/pubkeys", json={"query": "jack"}, headers=auth_headers,
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert [x["pubkey"] for x in body["results"]] == [VALID_PUBKEY_1, VALID_PUBKEY_2]
+        assert body["results"][0]["rank"] == pytest.approx(0.91)
+
+    def test_empty_query_returns_422(self, client, auth_headers):
+        r = client.post("/search/pubkeys", json={"query": ""}, headers=auth_headers)
+        assert r.status_code == 422
+
+    def test_query_too_long_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/search/pubkeys", json={"query": "x" * 513}, headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+
+# ===========================================================================
+# ORE-06 / ORE-07: /followers and /muters
+# ===========================================================================
+def _fake_top_inbound():
+    from app.schemas.schemas import UserConnection
+
+    return [
+        UserConnection(pubkey=VALID_PUBKEY_2, influence=0.91),
+        UserConnection(pubkey=VALID_PUBKEY_3, influence=0.50),
+    ]
+
+
+class TestFollowersMuters:
+    def test_followers_happy_path(self, client, auth_headers):
+        with patch(
+            "app.routers.open_ranking.followers_muters.get_top_inbound_by_influence",
+            new=AsyncMock(return_value=_fake_top_inbound()),
+        ), patch(
+            "app.routers.open_ranking.followers_muters.neo4j_driver"
+        ), patch(
+            "app.routers.open_ranking.followers_muters._redis_inbound_count",
+            new=AsyncMock(return_value=1234),
+        ):
+            r = client.post(
+                "/followers", json={"pubkey": VALID_PUBKEY_1}, headers=auth_headers,
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["total"] == 1234
+        assert [x["pubkey"] for x in body["results"]] == [VALID_PUBKEY_2, VALID_PUBKEY_3]
+        assert body["results"][0]["rank"] == pytest.approx(0.91)
+
+    def test_muters_happy_path(self, client, auth_headers):
+        with patch(
+            "app.routers.open_ranking.followers_muters.get_top_inbound_by_influence",
+            new=AsyncMock(return_value=_fake_top_inbound()),
+        ), patch(
+            "app.routers.open_ranking.followers_muters.neo4j_driver"
+        ), patch(
+            "app.routers.open_ranking.followers_muters._redis_inbound_count",
+            new=AsyncMock(return_value=42),
+        ):
+            r = client.post(
+                "/muters", json={"pubkey": VALID_PUBKEY_1}, headers=auth_headers,
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 42
+
+    def test_invalid_pubkey_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/followers", json={"pubkey": INVALID_PUBKEY}, headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+    def test_invalid_limit_returns_422(self, client, auth_headers):
+        r = client.post(
+            "/followers",
+            json={"pubkey": VALID_PUBKEY_1, "limit": -5},
+            headers=auth_headers,
+        )
+        assert r.status_code == 422
+
+
+# ===========================================================================
+# ORE-A: NWT authentication
+# ===========================================================================
+class TestNWTAuth:
+    """Auth is now mandatory on every data endpoint; the expected `aud` is
+    derived from settings.public_base_url (set to http://localhost:8000 in
+    the test env, so the audience is `localhost` — see tests.conftest.TEST_AUD).
+    """
+
+    def test_missing_authorization_returns_401(self, client):
+        r = client.post("/stats/pubkey", json={"pubkey": VALID_PUBKEY_1})
+        assert r.status_code == 401
+        assert r.headers.get("x-reason")
+
+    def test_valid_nwt_lets_request_through(self, client):
+        token, _pk = make_nwt()  # aud defaults to TEST_AUD
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(0.5)),
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={"pubkey": VALID_PUBKEY_1},
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text
+
+    def test_wrong_audience_rejected(self, client):
+        token, _pk = make_nwt(aud="other-provider.example")
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": f"Nostr {token}"},
+        )
+        assert r.status_code == 403
+        assert "aud" in r.headers.get("x-reason", "").lower()
+
+    def test_expired_token_rejected(self, client):
+        # Well outside the 60s skew window so the rejection is unambiguous.
+        token, _pk = make_nwt(exp=int(time.time()) - 600)
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": f"Nostr {token}"},
+        )
+        assert r.status_code == 403
+        assert "exp" in r.headers.get("x-reason", "").lower()
+
+    def test_wrong_kind_rejected(self, client):
+        token, _pk = make_nwt(kind=1)
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": f"Nostr {token}"},
+        )
+        assert r.status_code == 401
+
+    def test_garbage_token_rejected(self, client):
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": "Nostr not-base64!@#"},
+        )
+        assert r.status_code == 401
+
+    def test_capability_doc_remains_public(self, client):
+        # ORE-01: discovery MUST work without auth.
+        r = client.get("/.well-known/open-ranking.json")
+        assert r.status_code == 200
+
+    def test_multi_aud_token_accepted_when_one_matches(self, client):
+        from tests.conftest import TEST_AUD
+
+        token, _pk = make_nwt(
+            aud=["other-provider.example", TEST_AUD, "third.example"]
+        )
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(0.5)),
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={"pubkey": VALID_PUBKEY_1},
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text
+
+    def test_token_without_aud_rejected(self, client):
+        token, _pk = make_nwt(aud=None)
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": f"Nostr {token}"},
+        )
+        assert r.status_code == 403
+        assert "aud" in r.headers.get("x-reason", "").lower()
+
+    def test_nbf_in_future_rejected(self, client):
+        # nbf 10 minutes ahead — well outside the 60s clock-skew tolerance.
+        future_nbf = int(time.time()) + 600
+        token, _pk = make_nwt(nbf=future_nbf)
+        r = client.post(
+            "/stats/pubkey",
+            json={"pubkey": VALID_PUBKEY_1},
+            headers={"Authorization": f"Nostr {token}"},
+        )
+        assert r.status_code == 403
+        assert "nbf" in r.headers.get("x-reason", "").lower()
+
+    def test_exp_within_skew_tolerated(self, client):
+        # Token expired 5 seconds ago — inside the 60s allowed skew, so still
+        # accepted. Defends against tight clock drift between client/server.
+        token, _pk = make_nwt(exp=int(time.time()) - 5)
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(0.5)),
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={"pubkey": VALID_PUBKEY_1},
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text

--- a/tests/open_ranking/test_open_ranking_e2e.py
+++ b/tests/open_ranking/test_open_ranking_e2e.py
@@ -341,10 +341,20 @@ class TestFollowersMuters:
 # ORE-A: NWT authentication
 # ===========================================================================
 class TestNWTAuth:
-    """Auth is now mandatory on every data endpoint; the expected `aud` is
-    derived from settings.public_base_url (set to http://localhost:8000 in
-    the test env, so the audience is `localhost` — see tests.conftest.TEST_AUD).
+    """NWT enforcement when `settings.open_ranking_require_auth` is True. The
+    expected `aud` is derived from settings.public_base_url (set to
+    http://localhost:8000 in the test env, so the audience is `localhost` —
+    see tests.conftest.TEST_AUD).
+
+    The provider default is OPEN (auth off); this class flips the flag on for
+    its lifetime via the autouse fixture below.
     """
+
+    @pytest.fixture(autouse=True)
+    def _enable_auth(self, monkeypatch):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "open_ranking_require_auth", True)
 
     def test_missing_authorization_returns_401(self, client):
         r = client.post("/stats/pubkey", json={"pubkey": VALID_PUBKEY_1})
@@ -460,3 +470,139 @@ class TestNWTAuth:
                 headers={"Authorization": f"Nostr {token}"},
             )
         assert r.status_code == 200, r.text
+
+
+# Default observer = PERIODIC_GRAPERANK_PUBKEY in the test env (conftest).
+DEFAULT_OBSERVER = "be7bf5de068c1d842ed34a7c270507ec940f5ea51671cfd062a95e9d09420d0a"
+
+
+# ===========================================================================
+# Open mode (settings.open_ranking_require_auth is False — the provider default)
+# ===========================================================================
+class TestOpenModeNoAuth:
+    """With auth disabled (the default), data endpoints are reachable without
+    any NWT and resolve the observer per ORE-01 (global -> default observer,
+    personalized -> client `pov`).
+    """
+
+    def test_request_without_token_succeeds(self, client):
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview",
+            new=AsyncMock(return_value=_fake_overview(0.5)),
+        ):
+            r = client.post("/stats/pubkey", json={"pubkey": VALID_PUBKEY_1})
+        assert r.status_code == 200, r.text
+
+    def test_open_mode_uses_default_observer_for_global_algorithm(self, client):
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["observer"] = observer
+            return _fake_overview(0.5)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post("/stats/pubkey", json={"pubkey": VALID_PUBKEY_1})
+        assert r.status_code == 200, r.text
+        assert observed["observer"] == DEFAULT_OBSERVER
+
+    def test_open_mode_honours_client_pov(self, client):
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["observer"] = observer
+            return _fake_overview(0.5)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={
+                    "pubkey": VALID_PUBKEY_1,
+                    "algorithm": "graperank-pov",
+                    "pov": POV_PUBKEY,
+                },
+            )
+        assert r.status_code == 200, r.text
+        assert observed["observer"] == POV_PUBKEY
+
+
+# ===========================================================================
+# Auth mode: the observer is ALWAYS the signer (own-scores-only guarantee)
+# ===========================================================================
+class TestAuthModeForcesOwnObserver:
+    """When auth is enabled, the signer's own pubkey is forced as the observer
+    for every query — a client-supplied `pov` cannot be used to read another
+    observer's scores.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _enable_auth(self, monkeypatch):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "open_ranking_require_auth", True)
+
+    def test_pov_is_ignored_and_observer_is_signer(self, client):
+        token, signer = make_nwt()
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["observer"] = observer
+            return _fake_overview(0.5)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={
+                    "pubkey": VALID_PUBKEY_1,
+                    "algorithm": "graperank-pov",
+                    "pov": POV_PUBKEY,
+                },
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text
+        # pov (POV_PUBKEY) is ignored — the signer is the observer.
+        assert observed["observer"] == signer
+
+    def test_global_algorithm_also_forced_to_signer(self, client):
+        token, signer = make_nwt()
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["observer"] = observer
+            return _fake_overview(0.5)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={"pubkey": VALID_PUBKEY_1},  # default (global) algorithm
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text
+        assert observed["observer"] == signer
+
+    def test_pov_algorithm_without_pov_is_accepted(self, client):
+        # In auth mode the pov requirement is moot — the signer is the observer.
+        token, signer = make_nwt()
+        observed = {}
+
+        async def _capture(*, pubkey, observer):
+            observed["observer"] = observer
+            return _fake_overview(0.5)
+
+        with patch(
+            "app.routers.open_ranking.stats.get_user_overview", new=_capture
+        ):
+            r = client.post(
+                "/stats/pubkey",
+                json={"pubkey": VALID_PUBKEY_1, "algorithm": "graperank-pov"},
+                headers={"Authorization": f"Nostr {token}"},
+            )
+        assert r.status_code == 200, r.text
+        assert observed["observer"] == signer

--- a/tests/test_kind0_ingest.py
+++ b/tests/test_kind0_ingest.py
@@ -1,0 +1,62 @@
+"""kind-0 profile extraction: content JSON + tags merge.
+
+Covers docs/search-vs-tapestry.md §8.4.1 — newer clients mirror profile fields
+as tags (and use camelCase), and an empty event must not wipe a good profile.
+"""
+from __future__ import annotations
+
+import json
+
+from app.message_queue_tasks.process_strfry_event import _extract_kind0_profile
+
+
+def _event(content: str = "", tags: list | None = None) -> dict:
+    return {"pubkey": "p" * 64, "content": content, "tags": tags or []}
+
+
+def test_content_json_is_extracted():
+    ev = _event(content=json.dumps({"name": "alice", "about": "hi", "x": "ignored"}))
+    out = _extract_kind0_profile(ev)
+    assert out["name"] == "alice"
+    assert out["about"] == "hi"
+    assert "x" not in out  # only recognized PROFILE_FIELDS are kept
+
+
+def test_tag_only_event_is_extracted_not_wiped():
+    # Empty content but profile data in tags — must NOT be empty (the wipe bug).
+    ev = _event(
+        content="",
+        tags=[["alt", "..."], ["name", "bob"], ["nip05", "bob@example.com"]],
+    )
+    out = _extract_kind0_profile(ev)
+    assert out["name"] == "bob"
+    assert out["nip05"] == "bob@example.com"
+
+
+def test_content_wins_over_tags_on_conflict():
+    ev = _event(
+        content=json.dumps({"name": "from_content"}),
+        tags=[["name", "from_tag"], ["website", "https://w"]],
+    )
+    out = _extract_kind0_profile(ev)
+    assert out["name"] == "from_content"  # content is the base
+    assert out["website"] == "https://w"  # tags fill the gap
+
+
+def test_camelcase_displayname_is_normalized():
+    ev = _event(content=json.dumps({"displayName": "Carol"}))
+    out = _extract_kind0_profile(ev)
+    assert out["display_name"] == "Carol"
+    assert "displayName" not in out
+
+
+def test_username_is_extracted():
+    ev = _event(content=json.dumps({"username": "dave", "name": "Dave"}))
+    out = _extract_kind0_profile(ev)
+    assert out["username"] == "dave"
+
+
+def test_empty_or_malformed_event_yields_no_fields():
+    assert _extract_kind0_profile(_event(content="")) == {}
+    assert _extract_kind0_profile(_event(content="not json")) == {}
+    assert _extract_kind0_profile(_event(content=json.dumps({"x": "y"}))) == {}

--- a/tests/test_kind0_ingest.py
+++ b/tests/test_kind0_ingest.py
@@ -50,10 +50,27 @@ def test_camelcase_displayname_is_normalized():
     assert "displayName" not in out
 
 
-def test_username_is_extracted():
+def test_canonical_name_wins_over_deprecated_username():
+    # Both present: `name` is canonical (NIP-24), so `username` is dropped.
     ev = _event(content=json.dumps({"username": "dave", "name": "Dave"}))
     out = _extract_kind0_profile(ev)
-    assert out["username"] == "dave"
+    assert out["name"] == "Dave"
+    assert "username" not in out
+
+
+def test_deprecated_username_backfills_missing_name():
+    # Only the deprecated alias present → it populates the canonical `name`.
+    ev = _event(content=json.dumps({"username": "dave"}))
+    out = _extract_kind0_profile(ev)
+    assert out["name"] == "dave"
+    assert "username" not in out
+
+
+def test_blank_canonical_falls_back_to_deprecated():
+    # An empty/whitespace `name` is treated as missing → `username` backfills it.
+    ev = _event(content=json.dumps({"name": "   ", "username": "dave"}))
+    out = _extract_kind0_profile(ev)
+    assert out["name"] == "dave"
 
 
 def test_empty_or_malformed_event_yields_no_fields():

--- a/tests/test_nip50_relay.py
+++ b/tests/test_nip50_relay.py
@@ -354,7 +354,7 @@ def test_sort_rank_desc_selects_profile_and_preserves_vespa_order(
         frames = _drain_until_eose(ws, "s")
 
     assert calls[-1]["ranking_profile"] == "rank_desc"
-    assert calls[-1]["min_rank"] is None
+    assert calls[-1]["min_rank"] == 2.0  # default rank>=2 floor (§8.1)
     event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
     assert event_pks == [pk_c, pk_b, pk_a]
 
@@ -362,8 +362,9 @@ def test_sort_rank_desc_selects_profile_and_preserves_vespa_order(
 def test_sort_rank_asc_selects_profile_and_includes_zero_scores(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``sort:rank:asc`` uses the ``rank_asc`` profile and — unlike every other
-    path — keeps zero-score hits, since those are exactly what asc surfaces.
+    """``sort:rank:asc`` uses the ``rank_asc`` profile. The default rank>=2
+    filter still applies (Vespa drops sub-threshold hits in the gate), so the
+    Python zero-score include is off. See docs/search-vs-tapestry.md §8.1.
     """
     pk_low, pk_high = "a" * 64, "b" * 64
     calls: list[dict] = []
@@ -384,7 +385,8 @@ def test_sort_rank_asc_selects_profile_and_includes_zero_scores(
         frames = _drain_until_eose(ws, "s")
 
     assert calls[-1]["ranking_profile"] == "rank_asc"
-    assert calls[-1]["include_zero_score_results"] is True
+    assert calls[-1]["include_zero_score_results"] is False
+    assert calls[-1]["min_rank"] == 2.0
     event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
     assert event_pks == [pk_low, pk_high]
 
@@ -408,7 +410,7 @@ def test_filter_rank_gte_pushes_min_rank_to_vespa(
         )
         _drain_until_eose(ws, "s")
 
-    assert calls[-1]["ranking_profile"] == "rank_filtered"
+    assert calls[-1]["ranking_profile"] == "sort_followers"
     assert calls[-1]["min_rank"] == 50.0
 
 
@@ -428,7 +430,7 @@ def test_filter_rank_gt_uses_strict_lower_bound(
         )
         _drain_until_eose(ws, "s")
 
-    assert calls[-1]["ranking_profile"] == "rank_filtered"
+    assert calls[-1]["ranking_profile"] == "sort_followers"
     assert 50.0 < calls[-1]["min_rank"] < 51.0
 
 
@@ -500,19 +502,20 @@ def test_unknown_sort_metric_emits_notice_and_falls_back(
     )
     client = TestClient(app)
     with client.websocket_connect("/relay") as ws:
+        # `zaps` is not a supported sort metric (rank / followers are).
         ws.send_text(
             json.dumps(
-                ["REQ", "s", {"kinds": [0], "search": "x sort:followers:desc"}]
+                ["REQ", "s", {"kinds": [0], "search": "x sort:zaps:desc"}]
             )
         )
         frames = _drain_until_eose(ws, "s")
 
     notice = next((f for f in frames if f[0] == "NOTICE"), None)
     assert notice is not None
-    assert "followers" in notice[1].lower()
-    # A rejected sort falls back to the NIP-50 default ordering, which is
-    # trust-sorted-within-text = rank_desc (P0, docs/search-vs-tapestry.md §6).
-    assert calls[-1]["ranking_profile"] == "rank_desc"
+    assert "zaps" in notice[1].lower()
+    # A rejected sort falls back to the NIP-50 default = sort_followers
+    # (docs/search-vs-tapestry.md §8.1).
+    assert calls[-1]["ranking_profile"] == "sort_followers"
     event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
     assert event_pks == [pk_a, pk_b]
 
@@ -538,10 +541,10 @@ def test_unsupported_filter_op_emits_notice_and_applies_no_filter(
     notice = next((f for f in frames if f[0] == "NOTICE"), None)
     assert notice is not None
     assert "lte" in notice[1].lower()
-    # Unsupported op → no filter pushed (min_rank stays None); the relay still
-    # uses its trust-sorted default order (rank_desc) per P0 (§6).
-    assert calls[-1]["ranking_profile"] == "rank_desc"
-    assert calls[-1]["min_rank"] is None
+    # Unsupported op → no explicit filter; min_rank falls back to the default
+    # rank>=2 floor, and the relay uses its default sort_followers order (§8.1).
+    assert calls[-1]["ranking_profile"] == "sort_followers"
+    assert calls[-1]["min_rank"] == 2.0
 
 
 def test_cold_start_provisioning_fires_on_first_observer_search(

--- a/tests/test_nip50_relay.py
+++ b/tests/test_nip50_relay.py
@@ -1,0 +1,265 @@
+"""End-to-end tests for the NIP-50 /relay endpoint.
+
+The endpoint depends on two external systems:
+  * Vespa (for ranked profile search), and
+  * an internal strfry instance (for original signed kind-0 events).
+
+Both are stubbed at module-import boundaries so we can exercise the full
+NIP-01/NIP-50 framing without standing up real services. The tests use
+``TestClient.websocket_connect`` for the WS handler and a regular HTTP
+``GET /relay`` for NIP-11.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# App factory + stubs
+# ---------------------------------------------------------------------------
+def _build_nip50_app(
+    *,
+    vespa_results: list[dict],
+    strfry_events: dict[str, dict],
+    monkeypatch: pytest.MonkeyPatch,
+) -> FastAPI:
+    """Build a minimal FastAPI app with the NIP-50 router and external deps
+    replaced by deterministic in-memory stubs.
+    """
+    from app.routers.nip50 import router as nip50_module
+
+    async def _fake_vespa_search(
+        *, query_text: str, user_pubkey: str, hits: int, include_zero_score_results: bool
+    ) -> list[dict]:
+        # Echo back the canned results regardless of the query so individual
+        # tests stay focused on framing rather than ranking semantics.
+        return list(vespa_results)
+
+    async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
+        return {pk: strfry_events[pk] for pk in authors if pk in strfry_events}
+
+    monkeypatch.setattr(nip50_module, "vespa_search", _fake_vespa_search)
+    monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+
+    app = FastAPI()
+    app.include_router(nip50_module.router)
+    return app
+
+
+def _kind0_event(pubkey: str, name: str) -> dict[str, Any]:
+    # Realistic-looking kind-0 event. ``id``/``sig`` are placeholder hex
+    # strings — the relay only re-emits whatever strfry returned, so the
+    # framing tests don't need real signatures.
+    return {
+        "id": "a" * 64,
+        "pubkey": pubkey,
+        "created_at": 1700000000,
+        "kind": 0,
+        "tags": [],
+        "content": json.dumps({"name": name}),
+        "sig": "b" * 128,
+    }
+
+
+# ---------------------------------------------------------------------------
+# NIP-11
+# ---------------------------------------------------------------------------
+def test_nip11_document_advertises_search_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch
+    )
+    client = TestClient(app)
+
+    resp = client.get("/relay", headers={"Accept": "application/nostr+json"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/nostr+json")
+    body = resp.json()
+    assert 50 in body["supported_nips"]
+    assert 11 in body["supported_nips"]
+    assert body["search_capabilities"]["supported_kinds"] == [0]
+
+
+def test_nip11_landing_page_for_browser_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch
+    )
+    client = TestClient(app)
+    resp = client.get("/relay")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+
+
+# ---------------------------------------------------------------------------
+# WebSocket / NIP-50
+# ---------------------------------------------------------------------------
+def _drain_until_eose(ws, sub_id: str) -> list[list]:
+    """Collect frames from ``ws`` until we see EOSE for ``sub_id``."""
+    frames: list[list] = []
+    while True:
+        msg = ws.receive_json()
+        frames.append(msg)
+        if msg[0] == "EOSE" and msg[1] == sub_id:
+            return frames
+
+
+def test_search_returns_events_in_vespa_rank_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pk_a = "a" * 64
+    pk_b = "b" * 64
+    pk_c = "c" * 64  # in vespa, missing from strfry — must be skipped silently
+
+    app = _build_nip50_app(
+        vespa_results=[
+            {"pubkey": pk_a, "_quality_score": 0.9},
+            {"pubkey": pk_b, "_quality_score": 0.5},
+            {"pubkey": pk_c, "_quality_score": 0.1},
+        ],
+        strfry_events={
+            pk_a: _kind0_event(pk_a, "alice"),
+            pk_b: _kind0_event(pk_b, "bob"),
+        },
+        monkeypatch=monkeypatch,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "sub1", {"kinds": [0], "search": "alice"}])
+        )
+        frames = _drain_until_eose(ws, "sub1")
+
+    event_frames = [f for f in frames if f[0] == "EVENT"]
+    assert [f[2]["pubkey"] for f in event_frames] == [pk_a, pk_b]
+    assert frames[-1] == ["EOSE", "sub1"]
+
+
+def test_req_without_search_filter_returns_immediate_eose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": "a" * 64}],
+        strfry_events={"a" * 64: _kind0_event("a" * 64, "alice")},
+        monkeypatch=monkeypatch,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(json.dumps(["REQ", "sub2", {"kinds": [1]}]))
+        msg = ws.receive_json()
+
+    # No EVENT — we don't serve general nostr REQs.
+    assert msg == ["EOSE", "sub2"]
+
+
+def test_req_with_non_kind0_filter_returns_eose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": "a" * 64}],
+        strfry_events={"a" * 64: _kind0_event("a" * 64, "alice")},
+        monkeypatch=monkeypatch,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "sub3", {"kinds": [1], "search": "alice"}])
+        )
+        msg = ws.receive_json()
+
+    assert msg == ["EOSE", "sub3"]
+
+
+def test_observer_extension_is_stripped_from_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``observer:<hex>`` token must be removed from the query passed to
+    Vespa, and the observer pubkey must be used as the user perspective.
+    """
+    captured: dict[str, Any] = {}
+
+    from app.routers.nip50 import router as nip50_module
+
+    pk = "a" * 64
+    observer_pk = "d" * 64
+
+    async def _capturing_search(
+        *, query_text: str, user_pubkey: str, hits: int, include_zero_score_results: bool
+    ) -> list[dict]:
+        captured["query"] = query_text
+        captured["observer"] = user_pubkey
+        return [{"pubkey": pk}]
+
+    async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
+        return {pk: _kind0_event(pk, "alice")}
+
+    monkeypatch.setattr(nip50_module, "vespa_search", _capturing_search)
+    monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+
+    app = FastAPI()
+    app.include_router(nip50_module.router)
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                ["REQ", "sub4", {"search": f"alice observer:{observer_pk}"}]
+            )
+        )
+        _drain_until_eose(ws, "sub4")
+
+    assert captured["query"] == "alice"
+    assert captured["observer"] == observer_pk
+
+
+def test_publish_event_is_rejected_with_ok_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch
+    )
+    client = TestClient(app)
+
+    ev = _kind0_event("a" * 64, "alice")
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(json.dumps(["EVENT", ev]))
+        msg = ws.receive_json()
+
+    assert msg[0] == "OK"
+    assert msg[1] == ev["id"]
+    assert msg[2] is False
+
+
+def test_search_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    pks = [chr(ord("a") + i) * 64 for i in range(5)]
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": pk} for pk in pks],
+        strfry_events={pk: _kind0_event(pk, f"u{i}") for i, pk in enumerate(pks)},
+        monkeypatch=monkeypatch,
+    )
+    client = TestClient(app)
+
+    # We can't directly inspect the ``hits`` arg passed to vespa from here
+    # (stubbed search ignores it), but we can at least assert the framing
+    # stays well-formed when ``limit`` is supplied.
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "sub5", {"kinds": [0], "search": "u", "limit": 2}])
+        )
+        frames = _drain_until_eose(ws, "sub5")
+
+    event_frames = [f for f in frames if f[0] == "EVENT"]
+    # Stub returns all 5; the relay emits whatever vespa returns. Just sanity
+    # check that framing terminates and each frame is well-formed.
+    assert len(event_frames) == 5
+    assert frames[-1] == ["EOSE", "sub5"]

--- a/tests/test_nip50_relay.py
+++ b/tests/test_nip50_relay.py
@@ -510,8 +510,9 @@ def test_unknown_sort_metric_emits_notice_and_falls_back(
     notice = next((f for f in frames if f[0] == "NOTICE"), None)
     assert notice is not None
     assert "followers" in notice[1].lower()
-    # Default profile (no override) when the sort is rejected, order preserved.
-    assert calls[-1]["ranking_profile"] is None
+    # A rejected sort falls back to the NIP-50 default ordering, which is
+    # trust-sorted-within-text = rank_desc (P0, docs/search-vs-tapestry.md §6).
+    assert calls[-1]["ranking_profile"] == "rank_desc"
     event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
     assert event_pks == [pk_a, pk_b]
 
@@ -537,7 +538,9 @@ def test_unsupported_filter_op_emits_notice_and_applies_no_filter(
     notice = next((f for f in frames if f[0] == "NOTICE"), None)
     assert notice is not None
     assert "lte" in notice[1].lower()
-    assert calls[-1]["ranking_profile"] is None
+    # Unsupported op → no filter pushed (min_rank stays None); the relay still
+    # uses its trust-sorted default order (rank_desc) per P0 (§6).
+    assert calls[-1]["ranking_profile"] == "rank_desc"
     assert calls[-1]["min_rank"] is None
 
 

--- a/tests/test_nip50_relay.py
+++ b/tests/test_nip50_relay.py
@@ -27,24 +27,54 @@ def _build_nip50_app(
     vespa_results: list[dict],
     strfry_events: dict[str, dict],
     monkeypatch: pytest.MonkeyPatch,
+    calls: list[dict] | None = None,
 ) -> FastAPI:
     """Build a minimal FastAPI app with the NIP-50 router and external deps
     replaced by deterministic in-memory stubs.
+
+    If ``calls`` is provided, every ``vespa_search`` invocation appends its
+    kwargs to it. Sort/filter is pushed into Vespa (via ``ranking_profile`` +
+    ``min_rank``), so the stub does NOT re-order or drop results — it echoes the
+    canned list in order. Tests assert the router asked Vespa for the right
+    profile/min_rank and preserved Vespa's ordering, not that Python re-ranked.
     """
     from app.routers.nip50 import router as nip50_module
 
     async def _fake_vespa_search(
-        *, query_text: str, user_pubkey: str, hits: int, include_zero_score_results: bool
+        *,
+        query_text: str,
+        user_pubkey: str,
+        hits: int,
+        include_zero_score_results: bool,
+        ranking_profile: str | None = None,
+        min_rank: float | None = None,
     ) -> list[dict]:
-        # Echo back the canned results regardless of the query so individual
-        # tests stay focused on framing rather than ranking semantics.
-        return list(vespa_results)
+        if calls is not None:
+            calls.append(
+                {
+                    "query_text": query_text,
+                    "user_pubkey": user_pubkey,
+                    "hits": hits,
+                    "include_zero_score_results": include_zero_score_results,
+                    "ranking_profile": ranking_profile,
+                    "min_rank": min_rank,
+                }
+            )
+        # The real vespa.search() trims to `hits`; mirror that so the limit/hits
+        # path is exercised faithfully (the router no longer trims in Python).
+        return list(vespa_results)[:hits]
 
     async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
         return {pk: strfry_events[pk] for pk in authors if pk in strfry_events}
 
+    async def _noop_provision(_observer: str) -> None:
+        return None
+
     monkeypatch.setattr(nip50_module, "vespa_search", _fake_vespa_search)
     monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+    # Cold-start provisioning hits Redis + the DB; both stubbed out by
+    # default. Individual tests that exercise provisioning override this.
+    monkeypatch.setattr(nip50_module, "_maybe_provision_observer", _noop_provision)
 
     app = FastAPI()
     app.include_router(nip50_module.router)
@@ -194,7 +224,13 @@ def test_observer_extension_is_stripped_from_query(
     observer_pk = "d" * 64
 
     async def _capturing_search(
-        *, query_text: str, user_pubkey: str, hits: int, include_zero_score_results: bool
+        *,
+        query_text: str,
+        user_pubkey: str,
+        hits: int,
+        include_zero_score_results: bool,
+        ranking_profile: str | None = None,
+        min_rank: float | None = None,
     ) -> list[dict]:
         captured["query"] = query_text
         captured["observer"] = user_pubkey
@@ -203,8 +239,12 @@ def test_observer_extension_is_stripped_from_query(
     async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
         return {pk: _kind0_event(pk, "alice")}
 
+    async def _noop_provision(_observer: str) -> None:
+        return None
+
     monkeypatch.setattr(nip50_module, "vespa_search", _capturing_search)
     monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+    monkeypatch.setattr(nip50_module, "_maybe_provision_observer", _noop_provision)
 
     app = FastAPI()
     app.include_router(nip50_module.router)
@@ -240,7 +280,12 @@ def test_publish_event_is_rejected_with_ok_false(
     assert msg[2] is False
 
 
-def test_search_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_search_limit_truncates_emitted_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``limit`` in the NIP-01 filter caps the number of EVENT frames the
+    relay emits, even when the underlying search backend returns more.
+    """
     pks = [chr(ord("a") + i) * 64 for i in range(5)]
     app = _build_nip50_app(
         vespa_results=[{"pubkey": pk} for pk in pks],
@@ -249,9 +294,6 @@ def test_search_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     client = TestClient(app)
 
-    # We can't directly inspect the ``hits`` arg passed to vespa from here
-    # (stubbed search ignores it), but we can at least assert the framing
-    # stays well-formed when ``limit`` is supplied.
     with client.websocket_connect("/relay") as ws:
         ws.send_text(
             json.dumps(["REQ", "sub5", {"kinds": [0], "search": "u", "limit": 2}])
@@ -259,7 +301,370 @@ def test_search_limit_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
         frames = _drain_until_eose(ws, "sub5")
 
     event_frames = [f for f in frames if f[0] == "EVENT"]
-    # Stub returns all 5; the relay emits whatever vespa returns. Just sanity
-    # check that framing terminates and each frame is well-formed.
-    assert len(event_frames) == 5
+    assert len(event_frames) == 2
+    # Order preserved from Vespa rank order (stub returns pks in order).
+    assert [f[2]["pubkey"] for f in event_frames] == pks[:2]
     assert frames[-1] == ["EOSE", "sub5"]
+
+
+# ---------------------------------------------------------------------------
+# Path A extensions: sort, filter, cold-start
+# ---------------------------------------------------------------------------
+def test_nip11_advertises_sort_and_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch
+    )
+    client = TestClient(app)
+    body = client.get(
+        "/relay", headers={"Accept": "application/nostr+json"}
+    ).json()
+    exts = body["search_capabilities"]["extensions"]
+    assert "rank" in exts["sort"]["metrics"]
+    assert "rank" in exts["filter"]["metrics"]
+    # Only lower-bound operators map to Vespa's rank-score-drop-limit push-down.
+    assert set(exts["filter"]["operators"]) == {"gte", "gt"}
+
+
+def test_sort_rank_desc_selects_profile_and_preserves_vespa_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``sort:rank:desc`` asks Vespa for the ``rank_desc`` profile (Vespa does
+    the ordering) and the relay emits events in the order Vespa returned them.
+    """
+    pk_a, pk_b, pk_c = "a" * 64, "b" * 64, "c" * 64
+    calls: list[dict] = []
+    # Vespa returns these already ordered; the relay must not reorder them.
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": pk_c}, {"pubkey": pk_b}, {"pubkey": pk_a}],
+        strfry_events={
+            pk_a: _kind0_event(pk_a, "a"),
+            pk_b: _kind0_event(pk_b, "b"),
+            pk_c: _kind0_event(pk_c, "c"),
+        },
+        monkeypatch=monkeypatch,
+        calls=calls,
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"kinds": [0], "search": "x sort:rank:desc"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert calls[-1]["ranking_profile"] == "rank_desc"
+    assert calls[-1]["min_rank"] is None
+    event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
+    assert event_pks == [pk_c, pk_b, pk_a]
+
+
+def test_sort_rank_asc_selects_profile_and_includes_zero_scores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``sort:rank:asc`` uses the ``rank_asc`` profile and — unlike every other
+    path — keeps zero-score hits, since those are exactly what asc surfaces.
+    """
+    pk_low, pk_high = "a" * 64, "b" * 64
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": pk_low}, {"pubkey": pk_high}],
+        strfry_events={
+            pk_low: _kind0_event(pk_low, "low"),
+            pk_high: _kind0_event(pk_high, "high"),
+        },
+        monkeypatch=monkeypatch,
+        calls=calls,
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"kinds": [0], "search": "x sort:rank:asc"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert calls[-1]["ranking_profile"] == "rank_asc"
+    assert calls[-1]["include_zero_score_results"] is True
+    event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
+    assert event_pks == [pk_low, pk_high]
+
+
+def test_filter_rank_gte_pushes_min_rank_to_vespa(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``filter:rank:gte:50`` selects the filtered profile and pushes the
+    threshold down as ``min_rank`` (Vespa drops sub-threshold hits, not Python).
+    """
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch, calls=calls
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                ["REQ", "s", {"kinds": [0], "search": "x filter:rank:gte:50"}]
+            )
+        )
+        _drain_until_eose(ws, "s")
+
+    assert calls[-1]["ranking_profile"] == "rank_filtered"
+    assert calls[-1]["min_rank"] == 50.0
+
+
+def test_filter_rank_gt_uses_strict_lower_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``gt`` is pushed down as a ``min_rank`` just above the value, so a hit
+    scoring exactly the value is excluded."""
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch, calls=calls
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"kinds": [0], "search": "x filter:rank:gt:50"}])
+        )
+        _drain_until_eose(ws, "s")
+
+    assert calls[-1]["ranking_profile"] == "rank_filtered"
+    assert 50.0 < calls[-1]["min_rank"] < 51.0
+
+
+def test_filter_and_sort_compose_into_profile_and_min_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sort picks the profile; a filter sets min_rank — both reach Vespa."""
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch, calls=calls
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                [
+                    "REQ",
+                    "s",
+                    {"kinds": [0], "search": "x filter:rank:gte:40 sort:rank:desc"},
+                ]
+            )
+        )
+        _drain_until_eose(ws, "s")
+
+    assert calls[-1]["ranking_profile"] == "rank_desc"
+    assert calls[-1]["min_rank"] == 40.0
+
+
+def test_multiple_filters_take_most_restrictive_lower_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AND-ed filter tokens collapse to the highest lower bound."""
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch, calls=calls
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                [
+                    "REQ",
+                    "s",
+                    {"kinds": [0], "search": "x filter:rank:gte:30 filter:rank:gte:70"},
+                ]
+            )
+        )
+        _drain_until_eose(ws, "s")
+
+    assert calls[-1]["min_rank"] == 70.0
+
+
+def test_unknown_sort_metric_emits_notice_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsupported ``sort:`` metric must not silently change behavior —
+    the relay NOTICEs the client and uses the default profile (no override).
+    """
+    pk_a, pk_b = "a" * 64, "b" * 64
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": pk_a}, {"pubkey": pk_b}],
+        strfry_events={
+            pk_a: _kind0_event(pk_a, "a"),
+            pk_b: _kind0_event(pk_b, "b"),
+        },
+        monkeypatch=monkeypatch,
+        calls=calls,
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                ["REQ", "s", {"kinds": [0], "search": "x sort:followers:desc"}]
+            )
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    notice = next((f for f in frames if f[0] == "NOTICE"), None)
+    assert notice is not None
+    assert "followers" in notice[1].lower()
+    # Default profile (no override) when the sort is rejected, order preserved.
+    assert calls[-1]["ranking_profile"] is None
+    event_pks = [f[2]["pubkey"] for f in frames if f[0] == "EVENT"]
+    assert event_pks == [pk_a, pk_b]
+
+
+def test_unsupported_filter_op_emits_notice_and_applies_no_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``lte``/``lt``/``eq`` can't be pushed into Vespa's lower-bound cut-off;
+    the relay NOTICEs and applies no filter rather than guessing."""
+    calls: list[dict] = []
+    app = _build_nip50_app(
+        vespa_results=[], strfry_events={}, monkeypatch=monkeypatch, calls=calls
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                ["REQ", "s", {"kinds": [0], "search": "x filter:rank:lte:50"}]
+            )
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    notice = next((f for f in frames if f[0] == "NOTICE"), None)
+    assert notice is not None
+    assert "lte" in notice[1].lower()
+    assert calls[-1]["ranking_profile"] is None
+    assert calls[-1]["min_rank"] is None
+
+
+def test_cold_start_provisioning_fires_on_first_observer_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a NEW observer is supplied via ``observer:<hex>``, the relay
+    must enqueue a GrapeRank job for that observer (fire-and-forget). A
+    second search for the same observer must NOT re-enqueue (Redis dedup).
+    """
+    from app.routers.nip50 import router as nip50_module
+
+    pk = "a" * 64
+    observer_pk = "d" * 64
+
+    calls: list[str] = []
+
+    async def _fake_vespa_search(
+        *,
+        query_text: str,
+        user_pubkey: str,
+        hits: int,
+        include_zero_score_results: bool,
+        ranking_profile: str | None = None,
+        min_rank: float | None = None,
+    ) -> list[dict]:
+        return [{"pubkey": pk, "_quality_score": 0}]
+
+    async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
+        return {pk: _kind0_event(pk, "alice")}
+
+    async def _spy_provision(observer: str) -> None:
+        # Record every provisioning call so the test can assert on the
+        # de-duplication behavior across multiple searches.
+        calls.append(observer)
+
+    monkeypatch.setattr(nip50_module, "vespa_search", _fake_vespa_search)
+    monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+    monkeypatch.setattr(nip50_module, "_maybe_provision_observer", _spy_provision)
+
+    app = FastAPI()
+    app.include_router(nip50_module.router)
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s1", {"search": f"alice observer:{observer_pk}"}])
+        )
+        _drain_until_eose(ws, "s1")
+        ws.send_text(
+            json.dumps(["REQ", "s2", {"search": f"bob observer:{observer_pk}"}])
+        )
+        _drain_until_eose(ws, "s2")
+
+    # Both searches call the helper; the helper itself is responsible for
+    # the Redis NX dedup. Here we just verify the relay fired it with the
+    # caller-supplied observer (not the default observer).
+    assert calls == [observer_pk, observer_pk]
+
+
+def test_cold_start_not_fired_for_default_observer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the client omits ``observer:``, the relay falls back to the
+    instance's default observer and must NOT fire cold-start provisioning
+    (the default observer is provisioned by the periodic graperank cronjob).
+    """
+    from app.routers.nip50 import router as nip50_module
+
+    pk = "a" * 64
+    calls: list[str] = []
+
+    async def _fake_vespa_search(
+        *,
+        query_text: str,
+        user_pubkey: str,
+        hits: int,
+        include_zero_score_results: bool,
+        ranking_profile: str | None = None,
+        min_rank: float | None = None,
+    ) -> list[dict]:
+        return [{"pubkey": pk}]
+
+    async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
+        return {pk: _kind0_event(pk, "alice")}
+
+    async def _spy_provision(observer: str) -> None:
+        calls.append(observer)
+
+    monkeypatch.setattr(nip50_module, "vespa_search", _fake_vespa_search)
+    monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+    monkeypatch.setattr(nip50_module, "_maybe_provision_observer", _spy_provision)
+
+    app = FastAPI()
+    app.include_router(nip50_module.router)
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(json.dumps(["REQ", "s", {"search": "alice"}]))
+        _drain_until_eose(ws, "s")
+
+    assert calls == []
+
+
+def test_pure_extension_query_returns_eose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A search string containing ONLY extension tokens (no query text) is
+    rejected with an immediate EOSE — there's nothing to actually search.
+    """
+    app = _build_nip50_app(
+        vespa_results=[{"pubkey": "a" * 64}],
+        strfry_events={"a" * 64: _kind0_event("a" * 64, "alice")},
+        monkeypatch=monkeypatch,
+    )
+    client = TestClient(app)
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                [
+                    "REQ",
+                    "s",
+                    {"search": f"observer:{'d' * 64} sort:rank:desc"},
+                ]
+            )
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert not [f for f in frames if f[0] == "EVENT"]
+    assert frames[-1] == ["EOSE", "s"]


### PR DESCRIPTION
Summary

Reworks Nostr-profile search end-to-end: a trust-aware Vespa ranking model, an expanded/searchable field set, a new OpenRanking (ORE) HTTP API, and a NIP-50 relay search surface. Also hardens kind-0 ingestion (deprecated-field resolution, tag merging, control-char sanitizing) and adds ops tooling to backfill Vespa.

What's included

1. Vespa search ranking overhaul
- New default sort_followers profile: IDF-diluted text score multiplied by a concave Web-of-Trust curve (wot_mult), with a min_rank cutoff and text_score_cutoff — so common words (e.g. primal.net nip05) no longer flood results, and trust modulates rather than swamps relevance.
- Match tiers: name > identity (nip05/lud16, IDF-scored) > affiliation (about/website) > gram/recall noise.
- Precision fixes: length-gated fuzzy edit distances, capped trigram weight, proximity term, stemming: none on name fields.

2. Expanded, searchable field set (P1)
- nip05 / lud16 / website promoted from summary-only to indexed + BM25-searchable.
- Deprecated-field resolution at ingest (NIP-24): username → name and displayName → display_name now fold into their canonical field via a single data-driven priority table; the redundant username Vespa field is removed. Only canonical PROFILE_FIELDS are stored.
- kind-0 content JSON + profile tags are merged (content wins; tags gap-fill); control chars stripped; empty events no longer wipe good profiles.

3. OpenRanking (ORE) API — new routers/open_ranking/* endpoints (rank, search, capabilities, stats, well-known) with schemas, Neo4j batch-influence helper, and env-flag NWT auth.

4. NIP-50 relay search — /relay websocket surface backed by the same Vespa client; sort/filter extensions pushed into Vespa rank profiles.

5. Ops tooling (scripts/) — kind-0 → Vespa re-feed (resumable, paced), bulk GrapeRank trigger for all observers, pubkey analyzer, and HTTP/NIP-50/ORE search test helpers.

6. Docs & tests — docs/search-vs-tapestry.md (design + runbook), precision/trust docs; tests for kind-0 ingest, NIP-50 relay, and ORE e2e.

Companion changes (separate repos — deploy together)

- nosfabrica-kube: deployed doc.sd (ranking + field changes, username removed) and validation-overrides.xml.
- search-inspector: vendored vespa_query.py kept in sync (username removed).

Testing

tests/test_kind0_ingest.py green (canonical-wins / deprecated-backfill / blank-fallback).
Tested on a staging environment end to end.