### PR TITLE
ORE-05 search: fix production ordering, align rank with the spec, rename algorithms

### DIFF
--- a/app/routers/open_ranking/capabilities.py
+++ b/app/routers/open_ranking/capabilities.py
@@ -38,22 +38,19 @@ CAPABILITY_DOC: dict[str, list[dict]] = {
     ],
     "/search/pubkeys": [
         {
-            "id": "name-trust",
-            "name": "Name + Trust",
+            "id": "relevance",
+            "name": "Relevance (global)",
             "description": (
-                "Profile text match (name / nip05 / about) weighted by the "
-                "provider's default observer GrapeRank. rank is the relative "
-                "relevance score used for ordering (higher = better match); "
-                "it is not a 0-100 trust score and is not comparable across "
-                "queries — use /rank/pubkeys for GrapeRank scores."
+                "kind 0 profile text-matching score multiplied by a "
+                "web-of-trust metric (default perspective)"
             ),
         },
         {
-            "id": "name-trust-pov",
-            "name": "Name + Trust (personalized)",
+            "id": "relevance-pov",
+            "name": "Relevance (personalized)",
             "description": (
-                "Same as name-trust, weighted by your own GrapeRank; rank is "
-                "the relative relevance score used for ordering."
+                "kind 0 profile text-matching score multiplied by a "
+                "web-of-trust metric (personalized)"
             ),
             "pov": True,
         },

--- a/app/routers/open_ranking/capabilities.py
+++ b/app/routers/open_ranking/capabilities.py
@@ -42,13 +42,19 @@ CAPABILITY_DOC: dict[str, list[dict]] = {
             "name": "Name + Trust",
             "description": (
                 "Profile text match (name / nip05 / about) weighted by the "
-                "provider's default observer GrapeRank."
+                "provider's default observer GrapeRank. rank is the relative "
+                "relevance score used for ordering (higher = better match); "
+                "it is not a 0-100 trust score and is not comparable across "
+                "queries — use /rank/pubkeys for GrapeRank scores."
             ),
         },
         {
             "id": "name-trust-pov",
             "name": "Name + Trust (personalized)",
-            "description": "Same as name-trust, weighted by your own GrapeRank.",
+            "description": (
+                "Same as name-trust, weighted by your own GrapeRank; rank is "
+                "the relative relevance score used for ordering."
+            ),
             "pov": True,
         },
     ],

--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -74,13 +74,17 @@ async def search_pubkeys(
     )
     sanitized = _SANITIZE_RE.sub("", req.query).strip()
 
-    # Vespa returns documents with `_quality_score` (the observer's score for
-    # the matched profile). That score IS the rank for ORE-05.
+    # ORE-05 requires results "sorted by rank in descending order", i.e. the
+    # returned rank MUST be the ordering key. That key is Vespa's relevance
+    # (text match x observer-trust multiplier) — the name-trust score this
+    # endpoint advertises — NOT the 0-100 Trusted-Assertions GrapeRank value
+    # (clients get that from /rank/pubkeys). Vespa already returns hits in
+    # relevance-descending order, so the response is sorted by construction.
     #
     # ranking_profile and min_rank are explicit on purpose: deployed schemas
     # don't all give query(min_rank) a usable default, and omitting it has
     # degraded sort_followers to pure-text ordering in production. 0.0 keeps
-    # zero-score hits in the results (they surface with rank 0.0).
+    # zero-trust profiles in the results.
     hits = await vespa_search(
         query_text=sanitized,
         user_pubkey=observer,
@@ -96,7 +100,7 @@ async def search_pubkeys(
         if not isinstance(pk, str):
             continue
         results.append(
-            RankResult(pubkey=pk, rank=_safe_rank(h.get("_quality_score")))
+            RankResult(pubkey=pk, rank=_safe_rank(h.get("_relevance")))
         )
 
     return SearchPubkeysResponse(

--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -7,6 +7,7 @@ import re
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from app.core.vespa import RANK_PROFILE_SORT_FOLLOWERS
 from app.core.vespa import search as vespa_search
 from app.routers.open_ranking.capabilities import resolve_algorithm
 from app.routers.open_ranking.common import (
@@ -75,11 +76,18 @@ async def search_pubkeys(
 
     # Vespa returns documents with `_quality_score` (the observer's score for
     # the matched profile). That score IS the rank for ORE-05.
+    #
+    # ranking_profile and min_rank are explicit on purpose: deployed schemas
+    # don't all give query(min_rank) a usable default, and omitting it has
+    # degraded sort_followers to pure-text ordering in production. 0.0 keeps
+    # zero-score hits in the results (they surface with rank 0.0).
     hits = await vespa_search(
         query_text=sanitized,
         user_pubkey=observer,
         hits=limit,
         include_zero_score_results=True,
+        ranking_profile=RANK_PROFILE_SORT_FOLLOWERS,
+        min_rank=0.0,
     )
 
     results: list[RankResult] = []

--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -76,7 +76,7 @@ async def search_pubkeys(
 
     # ORE-05 requires results "sorted by rank in descending order", i.e. the
     # returned rank MUST be the ordering key. That key is Vespa's relevance
-    # (text match x observer-trust multiplier) — the name-trust score this
+    # (text match x observer-trust multiplier) — the "relevance" score this
     # endpoint advertises — NOT the 0-100 Trusted-Assertions GrapeRank value
     # (clients get that from /rank/pubkeys). Vespa already returns hits in
     # relevance-descending order, so the response is sorted by construction.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -51,11 +51,11 @@ need **no `.env`**; override the target via `BRAINSTORM_HTTP` / `BRAINSTORM_WS`.
 - **`search_open_ranking.sh "<query>" [limit] [--pov <hex>] [--algo <id>]`** —
   ORE-05 `POST /search/pubkeys`, **unsigned** (ORE-05 auth is optional and
   currently off). Stdlib-only. `--pov` only matters with a *personalized*
-  algorithm, so it auto-selects `name-trust-pov` (the default `name-trust` is
+  algorithm, so it auto-selects `relevance-pov` (the default `relevance` is
   global and ignores pov per ORE-01).
 - **`search_open_ranking.py --query <q> [--pov <hex>] [--algo <id>] [--sign|--nsec ...]`**
   — same endpoint, but can **sign** an NWT so the observer = signer. Observer
-  priority: signer (when signed) → `--pov` (auto `name-trust-pov`) → server
+  priority: signer (when signed) → `--pov` (auto `relevance-pov`) → server
   default. Needs `requests` + `nostr-sdk` (poetry env), like
   `smoke_open_ranking.py`; no `.env` required.
 

--- a/scripts/search_open_ranking.py
+++ b/scripts/search_open_ranking.py
@@ -102,7 +102,7 @@ def main() -> int:
         default=None,
         help=(
             "ORE-05 algorithm id. pov only applies to the personalized algorithm "
-            "(name-trust-pov), so --pov auto-selects it unless --algo is given."
+            "(relevance-pov), so --pov auto-selects it unless --algo is given."
         ),
     )
     p.add_argument("--limit", type=int, default=15)
@@ -123,8 +123,8 @@ def main() -> int:
     observer_desc = "server default"
 
     # pov is honored only by a pov-based algorithm; default to the personalized
-    # one when --pov is given (the default name-trust algorithm ignores pov).
-    algo = args.algo or ("name-trust-pov" if args.pov else None)
+    # one when --pov is given (the default relevance algorithm ignores pov).
+    algo = args.algo or ("relevance-pov" if args.pov else None)
     if algo:
         body["algorithm"] = algo
 

--- a/scripts/search_open_ranking.sh
+++ b/scripts/search_open_ranking.sh
@@ -4,9 +4,9 @@
 # so a plain unsigned POST works — handy for quick testing.
 #
 # To rank from a specific observer, pass --pov <hex>. NOTE: pov only takes
-# effect with the *personalized* algorithm (name-trust-pov); the default
-# algorithm (name-trust) is global and ignores pov per ORE-01. This script
-# auto-selects name-trust-pov whenever you pass --pov (override with --algo).
+# effect with the *personalized* algorithm (relevance-pov); the default
+# algorithm (relevance) is global and ignores pov per ORE-01. This script
+# auto-selects relevance-pov whenever you pass --pov (override with --algo).
 # (To rank AS a signed observer you need the Python version,
 # search_open_ranking.py, which signs the NWT.)
 #
@@ -38,7 +38,7 @@ QUERY="${ARGS[0]:?usage: search_open_ranking.sh \"<query>\" [limit] [--pov <hex>
 LIMIT="${ARGS[1]:-15}"
 
 # pov is honored only by a pov-based algorithm; default to the personalized one.
-[ -n "$POV" ] && [ -z "$ALGO" ] && ALGO="name-trust-pov"
+[ -n "$POV" ] && [ -z "$ALGO" ] && ALGO="relevance-pov"
 
 BODY=$(python3 -c 'import json,sys; b={"query":sys.argv[1],"limit":int(sys.argv[2])}; \
 pov,algo=sys.argv[3],sys.argv[4]; \

--- a/tests/open_ranking/test_open_ranking_e2e.py
+++ b/tests/open_ranking/test_open_ranking_e2e.py
@@ -247,7 +247,19 @@ class TestRankPubkeys:
 # ===========================================================================
 class TestSearchPubkeys:
     def test_happy_path(self, client, auth_headers):
-        async def fake_search(query_text, user_pubkey, hits, include_zero_score_results):
+        seen_kwargs = {}
+
+        async def fake_search(
+            query_text,
+            user_pubkey,
+            hits,
+            include_zero_score_results,
+            *,
+            ranking_profile=None,
+            min_rank=None,
+        ):
+            seen_kwargs["ranking_profile"] = ranking_profile
+            seen_kwargs["min_rank"] = min_rank
             return [
                 {"pubkey": VALID_PUBKEY_1, "_quality_score": 0.91},
                 {"pubkey": VALID_PUBKEY_2, "_quality_score": 0.45},
@@ -261,6 +273,13 @@ class TestSearchPubkeys:
         body = r.json()
         assert [x["pubkey"] for x in body["results"]] == [VALID_PUBKEY_1, VALID_PUBKEY_2]
         assert body["results"][0]["rank"] == pytest.approx(0.91)
+        # The profile and min_rank must be explicit — deployed Vespa schemas
+        # don't all default query(min_rank) to a no-op, and relying on the
+        # schema default has degraded ORE-05 to pure-text ordering in prod.
+        from app.core.vespa import RANK_PROFILE_SORT_FOLLOWERS
+
+        assert seen_kwargs["ranking_profile"] == RANK_PROFILE_SORT_FOLLOWERS
+        assert seen_kwargs["min_rank"] == 0.0
 
     def test_empty_query_returns_422(self, client, auth_headers):
         r = client.post("/search/pubkeys", json={"query": ""}, headers=auth_headers)

--- a/tests/open_ranking/test_open_ranking_e2e.py
+++ b/tests/open_ranking/test_open_ranking_e2e.py
@@ -260,9 +260,12 @@ class TestSearchPubkeys:
         ):
             seen_kwargs["ranking_profile"] = ranking_profile
             seen_kwargs["min_rank"] = min_rank
+            # _quality_score values deliberately contradict the relevance
+            # order: rank MUST come from _relevance (the ordering key ORE-05
+            # requires), not from the 0-100 trust score.
             return [
-                {"pubkey": VALID_PUBKEY_1, "_quality_score": 0.91},
-                {"pubkey": VALID_PUBKEY_2, "_quality_score": 0.45},
+                {"pubkey": VALID_PUBKEY_1, "_relevance": 11988.6, "_quality_score": 0.0},
+                {"pubkey": VALID_PUBKEY_2, "_relevance": 3018.9, "_quality_score": 61.0},
             ]
 
         with patch("app.routers.open_ranking.search.vespa_search", new=fake_search):
@@ -272,7 +275,10 @@ class TestSearchPubkeys:
         assert r.status_code == 200, r.text
         body = r.json()
         assert [x["pubkey"] for x in body["results"]] == [VALID_PUBKEY_1, VALID_PUBKEY_2]
-        assert body["results"][0]["rank"] == pytest.approx(0.91)
+        ranks = [x["rank"] for x in body["results"]]
+        assert ranks == pytest.approx([11988.6, 3018.9])
+        # ORE-05: "sorted by rank in descending order"
+        assert ranks == sorted(ranks, reverse=True)
         # The profile and min_rank must be explicit — deployed Vespa schemas
         # don't all default query(min_rank) to a no-op, and relying on the
         # schema default has degraded ORE-05 to pure-text ordering in prod.


### PR DESCRIPTION
Production `/search/pubkeys` returned pure-text ordering — zero-trust impersonators
ranked above genuine high-trust profiles — while `/search/byText` ordered correctly
against the same Vespa. Root cause: ORE-05 was the only caller that omitted
`ranking.features.query(min_rank)`. The deployed schema defaults it to -1e9, which
turns the `sort_followers` trust multiplier `1 + log(1 + user_score - min_rank)`
into a near-constant (~21.72 for scores 0 and 100 alike), erasing the trust term.

Three commits, one per concern:

1. **Pin ORE-05 to an explicit rank profile + `min_rank=0.0`** — mirrors the request
   shape `/search/byText` already sends. Restores trust-weighted ordering; zero-trust
   profiles stay in the result set (the schema gate is strict less-than).
2. **Return the ordering relevance as `rank`** — ORE-05 requires results "sorted by
   rank in descending order", i.e. rank must be the ordering key. That key is the
   text-match × web-of-trust relevance, not the 0–100 Trusted Assertions GrapeRank
   score (clients get that from `POST /rank/pubkeys`). Responses are now sorted by
   construction.
3. **Rename search algorithms** to `relevance` / `relevance-pov` ("Relevance
   (global)" / "Relevance (personalized)") with implementation-agnostic descriptions,
   so future tweaks to searched fields or the trust metric don't churn the
   capability doc.

**Breaking:** the old algorithm ids `name-trust` / `name-trust-pov` now return 422,
and the meaning of `rank` in ORE-05 responses changes from a 0–100 trust score to a
relative relevance value. ORE support is new enough that no external clients depend
on either.

**Verification:** 39 open-ranking e2e tests pass (new assertions pin the explicit
kwargs and the rank-from-relevance behavior). Verified live against a local stack
running the canonical deployed Vespa schema: the old request shape reproduces the
production bug; the fixed one restores trust-weighted, descending-sorted results.
No Vespa-side changes needed — deploying the server fixes production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
