### PR TITLE
fix(open-ranking): apply the main-search trust filters to ORE-05

### DIFF
--- a/app/routers/open_ranking/search.py
+++ b/app/routers/open_ranking/search.py
@@ -7,7 +7,7 @@ import re
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.core.vespa import RANK_PROFILE_SORT_FOLLOWERS
+from app.core.vespa import DEFAULT_MIN_RANK, RANK_PROFILE_SORT_FOLLOWERS
 from app.core.vespa import search as vespa_search
 from app.routers.open_ranking.capabilities import resolve_algorithm
 from app.routers.open_ranking.common import (
@@ -81,17 +81,21 @@ async def search_pubkeys(
     # (clients get that from /rank/pubkeys). Vespa already returns hits in
     # relevance-descending order, so the response is sorted by construction.
     #
-    # ranking_profile and min_rank are explicit on purpose: deployed schemas
-    # don't all give query(min_rank) a usable default, and omitting it has
-    # degraded sort_followers to pure-text ordering in production. 0.0 keeps
-    # zero-trust profiles in the results.
+    # The explicit arguments mirror /search/byText's defaults so ORE-05 and
+    # the main search page return the same results in the same order:
+    # min_rank=DEFAULT_MIN_RANK drops profiles below the observer-rank floor
+    # (influence*100 < 2) and include_zero_score_results=False drops unranked
+    # profiles. Without both filters, zero-trust exact-name matches enter at
+    # trust multiplier 1.0 and flood the results (bots above ranked users).
+    # min_rank must also never be omitted: the schema default (-1e9) flattens
+    # the trust multiplier to a constant and degrades ordering to pure text.
     hits = await vespa_search(
         query_text=sanitized,
         user_pubkey=observer,
         hits=limit,
-        include_zero_score_results=True,
+        include_zero_score_results=False,
         ranking_profile=RANK_PROFILE_SORT_FOLLOWERS,
-        min_rank=0.0,
+        min_rank=DEFAULT_MIN_RANK,
     )
 
     results: list[RankResult] = []

--- a/tests/open_ranking/test_open_ranking_e2e.py
+++ b/tests/open_ranking/test_open_ranking_e2e.py
@@ -260,6 +260,7 @@ class TestSearchPubkeys:
         ):
             seen_kwargs["ranking_profile"] = ranking_profile
             seen_kwargs["min_rank"] = min_rank
+            seen_kwargs["include_zero_score_results"] = include_zero_score_results
             # _quality_score values deliberately contradict the relevance
             # order: rank MUST come from _relevance (the ordering key ORE-05
             # requires), not from the 0-100 trust score.
@@ -279,13 +280,15 @@ class TestSearchPubkeys:
         assert ranks == pytest.approx([11988.6, 3018.9])
         # ORE-05: "sorted by rank in descending order"
         assert ranks == sorted(ranks, reverse=True)
-        # The profile and min_rank must be explicit — deployed Vespa schemas
-        # don't all default query(min_rank) to a no-op, and relying on the
-        # schema default has degraded ORE-05 to pure-text ordering in prod.
-        from app.core.vespa import RANK_PROFILE_SORT_FOLLOWERS
+        # These arguments must mirror /search/byText's defaults (UI parity):
+        # min_rank omitted degrades ordering to pure text (schema default
+        # -1e9), and min_rank=0 / include_zero=True floods results with
+        # zero-trust exact-name matches at multiplier 1.0.
+        from app.core.vespa import DEFAULT_MIN_RANK, RANK_PROFILE_SORT_FOLLOWERS
 
         assert seen_kwargs["ranking_profile"] == RANK_PROFILE_SORT_FOLLOWERS
-        assert seen_kwargs["min_rank"] == 0.0
+        assert seen_kwargs["min_rank"] == DEFAULT_MIN_RANK
+        assert seen_kwargs["include_zero_score_results"] is False
 
     def test_empty_query_returns_422(self, client, auth_headers):
         r = client.post("/search/pubkeys", json={"query": ""}, headers=auth_headers)


### PR DESCRIPTION
Staging comparison against the main search page (queries: jack, odell, vitor) showed ORE-05 padding its results with zero-influence profiles. Worst case "odell": the ranked candidate pool is 9 profiles, so 17 of ORE-05's top-20 were accounts with influence <= 0.003 (11 exactly 0), 12 of them tied at the identical rank value — zero-trust exact-name matches entering at trust multiplier 1.0 and crowding out genuinely ranked profiles (e.g. CITADEL DISPATCH, score 93) that byText surfaces.

Cause: ORE-05 passed min_rank=0.0 and include_zero_score_results=True, while the main search page (GET /search/byText with onlyRanked=true and the minRank default) filters both. In the schema, wot_mult() hard-drops docs below min_rank (multiplier 0.0 + rank-score-drop-limit); at min_rank=0 a user_score=0 doc survives at full text weight. The text_score_cutoff gate was never missing — sort_followers applies it on both paths.

Mirror byText's defaults: min_rank=DEFAULT_MIN_RANK (2.0 = influence 0.02 x 100) and include_zero_score_results=False. Verified on the local stack (canonical schema): ORE-05 and byText now return identical result lists for the same query.