### PR TITLE
Open ranking fix and update

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,6 +9,22 @@ AUTH_ACCESS_TOKEN_EXPIRE_MINUTES=60
 NEO4J_DB_URL=neo4j://localhost:7687
 NEO4J_DB_USERNAME=neo4j
 NEO4J_DB_PASSWORD=password
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# Nostr relay wiring. FROM = external source of events to sync in. TO = local
+# neofry relay; TA events publish to the local strfry relay (one-click stack
+# host ports 7777 / 7778). The PUBLIC_URL is embedded in published TA events —
+# point it at the relay's externally reachable address in prod.
+NOSTR_TRANSFER_FROM_RELAY=wss://wot.grapevine.network
+NOSTR_TRANSFER_TO_RELAY=ws://localhost:7777
+NOSTR_UPLOAD_TA_EVENTS_RELAY=ws://localhost:7778
+NOSTR_UPLOAD_TA_EVENTS_RELAY_PUBLIC_URL=ws://localhost:7778
+# True runs the initial full relay -> graph sync at startup and blocks the app
+# until it finishes. Enable for first-time bootstrap; false for day-to-day dev.
+PERFORM_NOSTR_FULL_SYNC=false
+FRONTEND_URL=http://localhost:3000
+# This server's own externally visible base URL (NIP-98 / NWT audience checks).
+PUBLIC_BASE_URL=http://localhost:8000
 ADMIN_ENABLED=false
 ADMIN_WHITELISTED_PUBKEYS=
 STALE_ONGOING_BRAINSTORM_REQUEST_THRESHOLD_HOURS=7

--- a/env.example
+++ b/env.example
@@ -31,6 +31,9 @@ STALE_ONGOING_BRAINSTORM_REQUEST_THRESHOLD_HOURS=7
 STALE_ONGOING_BRAINSTORM_REQUEST_CHECK_INTERVAL_MINUTES=30
 BLOCK_FREQUENT_GRAPERANK_REQUESTS=false
 BLOCK_FREQUENT_GRAPERANK_REQUESTS_MINUTES=30
+# Write-side gate: scorecards below this influence are neither published as TA
+# events nor mirrored into Vespa. 0.02 = deployed staging/local value (tests use 0.05).
+CUTOFF_OF_VALID_GRAPERANK_SCORES=0.02
 # Global kill-switch for the scheduler. Default off; enable per environment.
 SCHEDULER_ENABLED=false
 # Max scheduled runs publishing before the scheduler pauses admission.


### PR DESCRIPTION
## What

env.example was missing 10 settings that app/core/config.py declares as required (Field(...)), so a fresh deploy configured by copying env.example to .env failed Pydantic settings validation at startup:
- REDIS_HOST / REDIS_PORT
- NOSTR_TRANSFER_FROM_RELAY / NOSTR_TRANSFER_TO_RELAY
- NOSTR_UPLOAD_TA_EVENTS_RELAY / NOSTR_UPLOAD_TA_EVENTS_RELAY_PUBLIC_URL
- PERFORM_NOSTR_FULL_SYNC
- FRONTEND_URL / PUBLIC_BASE_URL
- CUTOFF_OF_VALID_GRAPERANK_SCORES

## Values chosen

Local-dev defaults, matching the one-click stack's host port mappings (neofry ws://localhost:7777, strfry ws://localhost:7778, redis 6379) and its local compose override (FRONTEND_URL=http://localhost:3000/, public relay URL pointing at the local strfry). PERFORM_NOSTR_FULL_SYNC=false because true blocks app startup on a full relay → graph sync; the inline comment says to enable it for first-time bootstrap. CUTOFF_OF_VALID_GRAPERANK_SCORES=0.02 matches the deployed staging/local value (tests use 0.05).

## Verification

Copied env.example to .env in an empty directory and instantiated app.core.config.Settings in a scrubbed environment (env -i, repo-pinned pydantic/pydantic-settings): validation now passes from env.example values alone. Before the change it failed with missing-field errors for the settings above.

Targets feat/shortest-path (which already contains the ORE-05 fixes from #47/#48) so everything rides in together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)