### PR TITLE
Split below-cutoff from full-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,10 @@ Vespa is **not** in this compose — it lives in `brainstorm_one_click_deploymen
 
 ## Things to know (gotchas)
 
+- **Prod timestamptz drift.** A few **production** timestamp columns are `timestamp WITH time zone` while migrations/staging/local are naive (`brainstorm_request.*`, most of `brainstorm_nsec.*`, `brainstorm_nostr_relay_transfer.*` — but NOT `last_time_published_graperank`, `scheduling`, `graperank_preset*`, `observerwhitelist`). asyncpg returns tz-aware datetimes from those, so Python-side subtraction against naive `datetime.now()` throws `can't subtract offset-naive and offset-aware datetimes` **on prod only**. Normalize aware→naive at any such boundary. Full column table, root cause, patched sites, and re-verify commands: [`docs/timestamptz-drift.md`](docs/timestamptz-drift.md).
+
 - **`periodic_graperank_pubkey`** is the default observer perspective for `/search/byText` when no `observerPubkey` is passed. Score mirroring to Vespa is **not** gated on it — `upsert_scores_to_vespa` runs for every observer. If `periodic_graperank_pubkey` is empty, search still works using the hardcoded default in the search router.
 - **`MAX_QUERY_WORDS = 6`** in `vespa.py` caps how many words of the search query get treated as separate match groups. Longer queries are truncated.
-- **`VESPA_FULL_SYNC = True`** in `upload_nostr_events.py` re-pushes every above-cutoff scorecard on each graperank run. Flip to `False` once Vespa is in sync to only push changed scores.
+- **`VESPA_FULL_SYNC` / `RELAY_FULL_SYNC`** (in `app/core/config.py`, both default `False`) re-push every above-cutoff scorecard on each graperank run when `True`. Delta is the steady state; drift is repaired by `FULL_SYNC_EVERY_N_RUNS` + the admin resync.
 - **Vespa needs `about_gram` to exist in the schema** for partial bio matches ("nosfab" → "nosfabrica") to work. If you wipe the volume and re-deploy, you also need to refeed (or `vespa reindex`) so the derived `about_gram` field gets populated.
 - **The brainstorm-server's docker-compose.yml** does NOT include Vespa. Vespa is provided by the sibling `brainstorm_one_click_deployment` repo. Set `VESPA_URL` accordingly.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -41,15 +41,15 @@ class Settings(BaseSettings):
     scheduler_fairness_enabled: bool = Field(default=False)
     periodic_graperank_pubkey: str = Field(default="")
     vespa_url: str = Field(...)
-    # Per-sink "fully re-assert state vs incremental" levers. Default True =
-    # current behavior (re-feed all above-cutoff + sweep all below-cutoff each
-    # run); False = incremental (changed scores + reported drops only).
-    #   vespa_full_sync → Vespa mirror (upserts + removes)
-    #   relay_full_sync → Nostr relay (kind-30382 TA republish + kind-5 deletes)
-    # When incremental, run a sink's flag True periodically to reconcile drift
-    # (the relay has no other reconciliation lever).
-    vespa_full_sync: bool = Field(default=True)
-    relay_full_sync: bool = Field(default=True)
+    # Per-sink publish mode. False (default) = only changed scores; True =
+    # re-assert every above-cutoff score each run. Re-assertion only, not deletes.
+    vespa_full_sync: bool = Field(default=False)  # Vespa upserts
+    relay_full_sync: bool = Field(default=False)  # kind-30382 TA republish
+    # Per-sink reaping: also delete EVERY below-cutoff Observee, not just
+    # those that fell off the baseline. Backwards-compat only — drains the legacy
+    # pre-cutoff backlog, then off. Not in env.example
+    relay_sweep_below_cutoff: bool = Field(default=False)
+    vespa_sweep_below_cutoff: bool = Field(default=False)
     # Count-gated parallel signing. At/below the threshold a publish run signs
     # via the simple sequential client loop (zero pool overhead — the common,
     # steady-state case). Above it, a *large* burst (first publish for an
@@ -59,12 +59,9 @@ class Settings(BaseSettings):
     sign_parallel_threshold: int = Field(default=10_000)
     sign_parallel_max_workers: int | None = Field(default=None)
     # Published-state-drift backstop: every Nth *scheduled* run for an observer
-    # forces a full re-assert on both sinks (delta can drift without self-repair).
-    # <= 0 disables the backstop (the per-run force_full_* overrides still work).
-    # Scheduled cadence is every 2h (12 runs/observer/day), so N=12 ≈ daily. The
-    # full run is the expensive path, so keep it infrequent: bump toward N=84
-    # (~weekly) once scheduling fans out to many observers.
-    full_sync_every_n_runs: int = Field(default=12)
+    # forces a full re-assert on both sinks.
+    # <= 0 disables the backstop.
+    full_sync_every_n_runs: int = Field(default=84)
     # Internal strfry relay used as the source of original signed kind-0 events
     # for the NIP-50 /relay endpoint. Not exposed externally — the FastAPI
     # /relay handler proxies search results out, never raw client traffic.

--- a/app/cronjobs/periodic_graperank_trigger.py
+++ b/app/cronjobs/periodic_graperank_trigger.py
@@ -42,6 +42,7 @@ async def _trigger_graperank(pubkey: str, reason: str) -> None:
         if not due:
             await increment_runs_since_full_on_db(db, pubkey=pubkey)
 
+        # Backstop forces a full RE-ASSERT only
         triggered = await create_brainstorm_request(
             db=db,
             algorithm="graperank",

--- a/app/message_queue_tasks/CLAUDE.md
+++ b/app/message_queue_tasks/CLAUDE.md
@@ -38,9 +38,10 @@ The longest module here. The main entry point is `process_nostr_upload_message(m
 
 ### `upsert_scores_to_vespa` — the score-mirror function
 
-- Two per-sink settings control "full re-assert vs incremental" (both `settings`, default `True`): `vespa_full_sync` (this Vespa mirror) and `relay_full_sync` (the Nostr relay — TA republish + kind-5 deletes). `True` pushes every above-cutoff scorecard each run; `False` only *changed* scores (`grape_rank_result.changedScorePubkeys`). Flip a sink `False` for steady state; run it `True` periodically to reconcile that sink's drift.
+- `vespa_full_sync` / `relay_full_sync` (both default `False` = delta): `False` publishes only _changed_ scores (`changedScorePubkeys`), `True` re-asserts every above-cutoff scorecard each run. Drift is repaired by the `full_sync_every_n_runs` backstop + admin `resync`, not by leaving a sink `True`. **Re-assertion only — never deletes.** The k8s charts set these per env and override the code default.
 - Below-cutoff scorecards are skipped for upserts.
-- Delete sets are computed **per sink** by `plan_publish` from a local diff (no relay/Vespa read): `fell_off = previously_published − currently_above_cutoff` (delta), plus every below-cutoff Observee on full-sync. The two lists are shared when both modes match.
+- Delete sets are computed **per sink** by `plan_publish` from a local diff (no relay/Vespa read): `fell_off = previously_published − currently_above_cutoff`. Shared as one list when both sweep modes match.
+- The **sweep** (`*_sweep_below_cutoff`, default off) adds every below-cutoff Observee to the delete set, reaping orphans the diff can't see. Backwards-compat drain: on to clear the legacy backlog, then off — it's mostly no-op deletes that each cost a tombstone/remove op. Not implied by full-sync, the backstop, or `resync`.
 - All ops are fanned out concurrently — see `batch_upsert_scores` in `app/core/vespa.py`.
 
 ### Order of operations matters

--- a/app/message_queue_tasks/upload_nostr_events.py
+++ b/app/message_queue_tasks/upload_nostr_events.py
@@ -76,32 +76,35 @@ def prepare_ta_inputs(
 
 
 def _delete_from_sets(
-    fell_off: set[str], below_cutoff: set[str], full_sync: bool
+    fell_off: set[str], below_cutoff: set[str], sweep_below_cutoff: bool
 ) -> list[str]:
     """The delete set from pre-built sets: Observees that fell off
-    (`previously - currently`), plus the full below-cutoff sweep on full-sync."""
-    return sorted(fell_off | below_cutoff if full_sync else fell_off)
+    (`previously - currently`), plus the whole below-cutoff sweep when enabled."""
+    return sorted(fell_off | below_cutoff if sweep_below_cutoff else fell_off)
 
 
 def compute_delete_observees(
     previously_published: list[str],
     currently_published: list[str],
     below_cutoff: list[str],
-    full_sync: bool,
+    sweep_below_cutoff: bool,
 ) -> list[str]:
-    """Observees whose score should be deleted this run — computed from a local
-    diff, no relay read. Sink-agnostic: relay and Vespa mirror the same logical
-    set (above-cutoff scores for the Observer), so both delete the same Observees,
-    differing only by their per-sink `full_sync` flag.
+    """One sink's delete set — computed from a local diff, no relay read.
 
-    Incremental: `previously_published - currently_published` (everything we'd
+    Default: `previously_published - currently_published` (everything we'd
     published that is no longer above cutoff; this subsumes both genuine removals
-    and below-cutoff drops, including ones the algo never reported). Full-sync
-    additionally sweeps every below-cutoff Observee to reconcile drift."""
+    and below-cutoff drops, including ones the algo never reported).
+
+    `sweep_below_cutoff` additionally deletes every below-cutoff Observee, reaping
+    orphans the diff can't see (legacy sub-cutoff rows, best-effort-write
+    leftovers). Nearly all of those were never published, so the sweep is mostly
+    no-op deletes that still cost a kind-5 tombstone (relay) / a remove op
+    (Vespa) — hence its own gate (`settings.*_sweep_below_cutoff`), NOT tied to
+    full-sync: full-sync re-asserts, it does not decide what to delete."""
     return _delete_from_sets(
         set(previously_published) - set(currently_published),
         set(below_cutoff),
-        full_sync,
+        sweep_below_cutoff,
     )
 
 
@@ -109,7 +112,11 @@ class PublishPlan(NamedTuple):
     """What one publish run does with an algo result, decided up front.
 
     `currently_published` is every above-cutoff Observee (the new published-state
-    to persist). `relay_deletes` / `vespa_deletes` are each sink's delete set."""
+    to persist). `relay_deletes` / `vespa_deletes` are each sink's delete set:
+    equal whenever both sinks sweep the same way, but genuinely independent,
+    because the sinks pay different prices for a sweep (a Vespa remove is a cheap
+    idempotent op; a relay delete costs a kind-5 tombstone) and an admin resync
+    can target one sink alone."""
 
     currently_published: list[str]
     relay_deletes: list[str]
@@ -120,16 +127,19 @@ def plan_publish(
     grape_rank_result: GrapeRankResult,
     previously_published: list[str],
     cutoff: float,
-    relay_full_sync: bool,
-    vespa_full_sync: bool,
+    sweep_relay: bool = False,
+    sweep_vespa: bool = False,
 ) -> PublishPlan:
     """Decide the per-sink delete sets + the new published-state from one algo
     result, with no relay read. Pure, so the whole publish decision is testable
     against algo results without DB/relay/signing.
 
     Partitions scorecards into above/below cutoff in a single pass, builds each
-    set once, and reuses them across both sinks — when the two `full_sync` flags
-    match (the common case) the delete set is computed once and shared."""
+    set once, and reuses them across both sinks — when the two sweep flags match
+    (the common case) the delete set is computed once and shared.
+
+    The delete sets do NOT depend on the full-sync flags — those decide what each
+    sink re-asserts, not what it deletes (see `compute_delete_observees`)."""
     assert grape_rank_result.scorecards is not None
     currently_published: list[str] = []
     above: set[str] = set()
@@ -142,11 +152,11 @@ def plan_publish(
             below.add(sc.observee)
 
     fell_off = set(previously_published) - above
-    relay_deletes = _delete_from_sets(fell_off, below, relay_full_sync)
+    relay_deletes = _delete_from_sets(fell_off, below, sweep_relay)
     vespa_deletes = (
         relay_deletes
-        if relay_full_sync == vespa_full_sync
-        else _delete_from_sets(fell_off, below, vespa_full_sync)
+        if sweep_relay == sweep_vespa
+        else _delete_from_sets(fell_off, below, sweep_vespa)
     )
     return PublishPlan(currently_published, relay_deletes, vespa_deletes)
 
@@ -480,18 +490,29 @@ async def process_nostr_upload_message(message: dict):
         with _timed(timings, "compute_deletes"):
             # One pass partitions scorecards into above/below cutoff and decides
             # both sinks' fetch-free local-diff delete sets (shared when the two
-            # full_sync modes match). The local diff subsumes the old
-            # dropped+missing set and catches drops the algo never reported.
+            # sweep modes match). The local diff subsumes the old dropped+missing
+            # set and catches drops the algo never reported. Independent of
+            # full-sync: that re-asserts, it does not delete.
             plan = plan_publish(
                 grape_rank_result,
                 previously_published=previously_published_pubkeys,
                 cutoff=settings.cutoff_of_valid_graperank_scores,
-                relay_full_sync=relay_full_sync,
-                vespa_full_sync=vespa_full_sync,
+                sweep_relay=settings.relay_sweep_below_cutoff,
+                sweep_vespa=settings.vespa_sweep_below_cutoff,
             )
             currently_published_pubkeys = plan.currently_published
             relay_pubkeys_to_delete = plan.relay_deletes
             vespa_pubkeys_to_delete = plan.vespa_deletes
+        # A sweep is a backlog-draining mode, not a steady state — say so loudly
+        # so it can't sit on unnoticed, billing no-op deletes every run.
+        if settings.relay_sweep_below_cutoff or settings.vespa_sweep_below_cutoff:
+            logger.warning(
+                f"below-cutoff sweep ENABLED for observer {observer} "
+                f"(relay={settings.relay_sweep_below_cutoff} "
+                f"vespa={settings.vespa_sweep_below_cutoff}): every run reaps every "
+                f"below-cutoff Observee. Turn *_SWEEP_BELOW_CUTOFF back off once the "
+                f"orphan backlog has drained."
+            )
         counts["n_above_cutoff"] = len(currently_published_pubkeys)
         counts["n_relay_deletes"] = len(relay_pubkeys_to_delete)
         counts["n_vespa_deletes"] = len(vespa_pubkeys_to_delete)

--- a/env.example
+++ b/env.example
@@ -23,14 +23,14 @@ SCHEDULER_INFLIGHT_TARGET=1
 SCHEDULER_FAIRNESS_ENABLED=false
 PERIODIC_GRAPERANK_PUBKEY=
 VESPA_URL=http://localhost:8080
-# Per-sink full-sync vs incremental publish mode. True (default) = re-feed every
-# above-cutoff scorecard + sweep all below-cutoff for deletion each run (backfill
-# / drift reconciliation). False = push only changed scores + graperank-reported
-# drops. Run a sink's flag True periodically to reconcile that sink's drift.
-#   VESPA_FULL_SYNC → Vespa mirror (upserts + removes)
-#   RELAY_FULL_SYNC → Nostr relay (kind-30382 TA republish + kind-5 deletes)
-VESPA_FULL_SYNC=true
-RELAY_FULL_SYNC=true
+# Per-sink publish mode: false (default) = only changed scores; true = re-assert
+# every above-cutoff score each run. Re-assertion only, not deletes.
+VESPA_FULL_SYNC=false
+RELAY_FULL_SYNC=false
+# Per-sink orphan reaping: also delete EVERY below-cutoff Observee, not just the
+# ones that fell off the baseline. On to drain a backlog, then off.
+RELAY_SWEEP_BELOW_CUTOFF=false
+VESPA_SWEEP_BELOW_CUTOFF=false
 # Count-gated parallel signing. Runs signing <= threshold events via the simple
 # sequential client loop (the common steady-state case, zero pool overhead);
 # above it a large burst (first publish for an Observer, big graph shift) shards
@@ -38,11 +38,9 @@ RELAY_FULL_SYNC=true
 # SIGN_PARALLEL_MAX_WORKERS defaults to os.cpu_count(); uncomment to override.
 SIGN_PARALLEL_THRESHOLD=10000
 # SIGN_PARALLEL_MAX_WORKERS=12
-# Published-state-drift backstop: every Nth scheduled run per observer forces a
-# full re-assert on both sinks (repairs delta drift). Scheduled cadence is 2h
-# (12 runs/day), so 12 ≈ daily; bump toward 84 (~weekly) when scheduling fans
-# out to many observers (full runs are the expensive path). <= 0 disables it.
-FULL_SYNC_EVERY_N_RUNS=12
+# Drift backstop: every Nth scheduled run per observer forces a full re-assert on
+# both sinks. Cadence is 2h, so 84 ≈ weekly. <= 0 disables it.
+FULL_SYNC_EVERY_N_RUNS=84
 # Optional Vespa feed tuning (plain os.getenv in app/core/vespa.py; sane defaults,
 # only set to override). Concurrency = simultaneous connections (the endpoint is
 # HTTP/1.1 — no multiplexing); connect-level failures are retried; HTTP/2 is a

--- a/scripts/clean_observer_orphans.py
+++ b/scripts/clean_observer_orphans.py
@@ -14,12 +14,13 @@ DRY-RUN by default (reports counts + a sample); pass --apply to delete. "Missing
 
 Scope is ONE observer (--observer <hex>) — everything stays bounded to that
 observer's cells/TAs (the Vespa visit records only their cells, not the corpus).
-For bulk drift use per-observer resync?target=vespa / the backstop.
+For bulk drift set *_SWEEP_BELOW_CUTOFF (resync/the backstop do NOT sweep).
 
 Safety cap (default target, --apply only): if the orphan count exceeds
 --max-orphans (abs) or --max-orphan-pct (% of published), the delete is SKIPPED
 and flagged — a huge count is usually the legacy pre-cutoff-fix backlog, which
-`resync?target=vespa` reaps ~99.9% (but NOT ghosts) more safely than a raw delete.
+the `*_SWEEP_BELOW_CUTOFF` drain reaps (but NOT ghosts) more safely than a raw
+delete.
 
 RUN IT INSIDE THE brainstorm-server POD/CONTAINER — DB, VESPA_URL, and the nsec
 key file (/run/secrets/nsec_encryption_keys) are already wired; nothing to
@@ -150,7 +151,7 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--observer", required=True, help="Observer pubkey (hex).")
     # Per observer only: the Vespa visit records just this observer's cells, so
-    # memory stays bounded. For bulk drift use resync?target=vespa / the backstop.
+    # memory stays bounded. For bulk drift set *_SWEEP_BELOW_CUTOFF.
     parser.add_argument("--sink", choices=["vespa", "relay", "both"], default="vespa")
     parser.add_argument(
         "--scan", help="strfry-scan JSONL, or '-' for stdin (required for relay/both)."

--- a/tests/test_publish_planning.py
+++ b/tests/test_publish_planning.py
@@ -40,8 +40,6 @@ def test_incremental_delta_run_publishes_only_changed_and_deletes_what_fell_off(
         run2,
         previously_published=["a", "b", "c"],
         cutoff=CUTOFF,
-        relay_full_sync=False,
-        vespa_full_sync=False,
     )
 
     # Both sinks delete c (it fell off); a/b unchanged, d is new.
@@ -66,8 +64,6 @@ def test_local_diff_catches_a_drop_the_algo_failed_to_report():
         run,
         previously_published=["a", "c"],
         cutoff=CUTOFF,
-        relay_full_sync=False,
-        vespa_full_sync=False,
     )
 
     # fell_off (previously_published - currently_above_cutoff) catches c despite
@@ -75,52 +71,80 @@ def test_local_diff_catches_a_drop_the_algo_failed_to_report():
     assert plan.relay_deletes == ["c"]
 
 
-def test_full_sync_on_10k_publishes_all_above_cutoff_and_sweeps_all_below():
+def test_sweep_on_10k_publishes_all_above_cutoff_and_sweeps_all_below():
     scores = {f"hi{i}": 0.50 for i in range(6000)}
     scores.update({f"lo{i}": 0.01 for i in range(4000)})
-    # No changed hint — full-sync ignores it and reconciles wholesale.
     run = _result(scores, changed=[])
 
     plan = plan_publish(
         run,
         previously_published=[],
         cutoff=CUTOFF,
-        relay_full_sync=True,
-        vespa_full_sync=True,
+        sweep_relay=True,
+        sweep_vespa=True,
     )
 
     assert len(plan.currently_published) == 6000
     assert len(plan.relay_deletes) == 4000  # every below-cutoff Observee swept
     assert plan.relay_deletes == plan.vespa_deletes  # matching modes share the set
-    published = prepare_ta_inputs(run, CUTOFF, full_sync=True)
-    assert len(published) == 6000  # full-sync signs ALL above-cutoff, not just changed
 
 
-def test_incremental_vs_full_sync_on_same_10k_result():
+def test_full_sync_does_not_drive_deletes():
+    # Regression: full-sync used to imply the below-cutoff sweep, so every full
+    # run emitted kind-5 tombstones for coordinates it had never published.
+    # full_sync now only decides re-assertion; the delete set is unaffected.
     scores = {f"hi{i}": 0.50 for i in range(6000)}
     scores.update({f"lo{i}": 0.01 for i in range(4000)})
     run = _result(scores, changed=[])  # a steady-state run: nothing changed
 
-    full = plan_publish(run, [], CUTOFF, relay_full_sync=True, vespa_full_sync=True)
-    incr = plan_publish(run, [], CUTOFF, relay_full_sync=False, vespa_full_sync=False)
+    plan = plan_publish(run, [], CUTOFF)  # sweep off (the default)
 
-    # The op-count gap issue 05 is about: full-sync sweeps 4000 deletes + re-signs
-    # 6000; the steady-state incremental run touches nothing.
-    assert len(full.relay_deletes) == 4000
-    assert incr.relay_deletes == []
+    assert plan.relay_deletes == []  # nothing was published, so nothing fell off
+    assert plan.vespa_deletes == []
+    # ...while full-sync still re-signs every above-cutoff TA.
+    assert len(prepare_ta_inputs(run, CUTOFF, full_sync=True)) == 6000
     assert prepare_ta_inputs(run, CUTOFF, full_sync=False) == []  # nothing to sign
 
 
-def test_plan_publish_splits_delete_sets_when_sinks_use_different_modes():
+def test_sweep_is_additive_to_the_fell_off_diff():
+    run = _result({"a": 0.90, "lo": 0.01}, changed=[])
+
+    swept = plan_publish(run, ["a", "x"], CUTOFF, sweep_relay=True, sweep_vespa=True)
+    plain = plan_publish(run, ["a", "x"], CUTOFF)
+
+    # "x" fell off the published baseline either way; the sweep adds "lo", which
+    # was never published (so its delete is a relay no-op that costs a tombstone).
+    assert plain.relay_deletes == ["x"]
+    assert swept.relay_deletes == ["lo", "x"]
+
+
+def test_plan_publish_splits_delete_sets_when_sinks_sweep_differently():
+    # Draining Vespa alone: its cheap removes reap "lo" while the relay pays no
+    # tombstone for it. Both sinks still delete "x", which genuinely fell off.
     run = _result({"a": 0.90, "lo": 0.01}, changed=[])
 
     plan = plan_publish(
         run,
-        previously_published=["a"],
+        previously_published=["a", "x"],
         cutoff=CUTOFF,
-        relay_full_sync=True,
-        vespa_full_sync=False,
+        sweep_relay=False,
+        sweep_vespa=True,
     )
 
-    assert plan.relay_deletes == ["lo"]  # full-sync sweeps the below-cutoff Observee
-    assert plan.vespa_deletes == []  # incremental: nothing fell off the published set
+    assert plan.relay_deletes == ["x"]  # diff only: no tombstone for "lo"
+    assert plan.vespa_deletes == ["lo", "x"]  # swept: the orphan cell goes too
+
+
+def test_only_the_sweep_reaps_an_orphan():
+    # "orph" is below cutoff and was never in the published baseline, so no
+    # `fell_off` diff can ever see it. Off (the default) it survives; the drain
+    # reaps it on the runs the scheduler already does — no extra work enqueued.
+    run = _result({"a": 0.90, "orph": 0.01}, changed=[])
+
+    off = plan_publish(run, ["a"], CUTOFF)
+    assert off.relay_deletes == []
+    assert off.vespa_deletes == []
+
+    draining = plan_publish(run, ["a"], CUTOFF, sweep_relay=True, sweep_vespa=True)
+    assert draining.relay_deletes == ["orph"]
+    assert draining.vespa_deletes == ["orph"]

--- a/tests/test_published_baseline.py
+++ b/tests/test_published_baseline.py
@@ -63,8 +63,6 @@ def test_retained_failed_delete_is_re_deleted_on_the_next_run():
         run,
         previously_published=["a", "gone"],  # 'gone' retained from a prior dirty run
         cutoff=CUTOFF,
-        relay_full_sync=False,
-        vespa_full_sync=False,
     )
     assert plan.relay_deletes == ["gone"]
     assert plan.vespa_deletes == ["gone"]

--- a/tests/test_relay_deletions.py
+++ b/tests/test_relay_deletions.py
@@ -80,20 +80,21 @@ def test_incremental_delete_set_is_previously_minus_currently_published():
         previously_published=["b", "x"],
         currently_published=["b", "c"],
         below_cutoff=[],
-        full_sync=False,
+        sweep_below_cutoff=False,
     )
 
     assert observees == ["x"]
 
 
-def test_full_sync_delete_set_also_sweeps_all_below_cutoff():
-    # Same diff as above ("x"), plus full-sync reconciliation sweeps every
+def test_sweep_below_cutoff_delete_set_also_sweeps_all_below_cutoff():
+    # Same diff as above ("x"), plus the opt-in drift sweep, which deletes every
     # below-cutoff Observee ("lo") even though it was never in previously/currently.
+    # Gated per-sink on `*_sweep_below_cutoff`, not full-sync.
     observees = compute_delete_observees(
         previously_published=["b", "x"],
         currently_published=["b", "c"],
         below_cutoff=["lo"],
-        full_sync=True,
+        sweep_below_cutoff=True,
     )
 
     assert observees == ["lo", "x"]  # sorted union, deduped
@@ -105,7 +106,7 @@ def test_delete_set_is_empty_when_nothing_dropped():
             previously_published=["b"],
             currently_published=["b", "c"],
             below_cutoff=[],
-            full_sync=False,
+            sweep_below_cutoff=False,
         )
         == []
     )


### PR DESCRIPTION
## Problem
`*_FULL_SYNC` conflated two unrelated decisions: **what a sink re-asserts and what a sink deletes**. Because full-sync implied the below-cutoff sweep, every full run emitted a delete for every below-cutoff Observee — ~176k removes/run on the 310k-scorecard staging Observer, nearly all no-ops (the relay held 0–487 of them), each still costing a kind-5 tombstone or a Vespa remove op. That sweep was also unavoidably coupled to re-assertion: you couldn't re-assert without reaping, or reap without re-asserting.

Both flags also defaulted to `True`, so the expensive path was the default one.

## Change
Two axes, two gates:

`VESPA_FULL_SYNC` / `RELAY_FULL_SYNC` — **re-assertion only, never deletes**. Now default false (delta: only changedScorePubkeys).
`RELAY_SWEEP_BELOW_CUTOFF` / `VESPA_SWEEP_BELOW_CUTOFF` — **new**, default `false`. Adds every below-cutoff Observee to that sink's delete set, reaping orphans the `previously_published − currently_above_cutoff` diff structurally cannot see (legacy sub-cutoff rows, best-effort-write leftovers). Backwards-compat drain: on to clear the legacy backlog, then off. Not implied by full-sync, the backstop, or `resync`.
Delete sets stay per-sink and independent — a Vespa remove is a cheap idempotent op, a relay delete costs a tombstone — so you can drain Vespa alone.

Also:

`FULL_SYNC_EVERY_N_RUNS` 12 → 84 (~weekly at the 2h scheduled cadence, was ~daily). The backstop forces a full re-assert only.
A sweep-enabled run logs a `WARNING` per observer.
