### PR TITLE
fix(nip50): fall back to the default observer when an observer has no scores

### DIFF
--- a/app/routers/nip50/router.py
+++ b/app/routers/nip50/router.py
@@ -480,6 +480,47 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
         await _send_json(ws, ["EOSE", sub_id])
         return
 
+    # Cold-start fallback. An observer whose GrapeRank job hasn't landed yet has
+    # no cell in the `quality_scores` tensor, so every document scores 0 for it
+    # and the min_rank floor (rank>=2 by default) drops the entire result set.
+    # Without this, a brand-new observer gets a silent empty answer on every
+    # search until provisioning completes — which reads as "the relay is broken"
+    # and contradicts the NIP-11 document, which promises that the search "falls
+    # back to the instance's default observer" meanwhile.
+    #
+    # Retrying only when the personalized pass came back empty keeps this off the
+    # hot path: an observer that already has scores never pays the second call,
+    # and the retry disappears on its own once provisioning lands.
+    used_fallback_observer = False
+    fallback_observer = default_observer_pubkey()
+    if not results and observer_override and observer != fallback_observer:
+        try:
+            results = await vespa_search(
+                query_text=query,
+                user_pubkey=fallback_observer,
+                hits=hits,
+                include_zero_score_results=include_unscored,
+                ranking_profile=ranking_profile,
+                min_rank=min_rank,
+            )
+        except Exception as exc:
+            # The personalized pass already succeeded (it was just empty), so a
+            # failing fallback degrades to that empty answer rather than turning
+            # a working search into an error.
+            logger.warning("nip50: default-observer fallback failed: %r", exc)
+            results = []
+        if results:
+            used_fallback_observer = True
+            await _send_json(
+                ws,
+                [
+                    "NOTICE",
+                    f"observer {observer_override[:12]}... has no GrapeRank "
+                    "scores yet; ranking from the instance's default observer "
+                    "while its computation completes",
+                ],
+            )
+
     # Results already arrive in Vespa rank order, filtered + sorted as asked.
     ranked_pubkeys: list[str] = []
     seen: set[str] = set()
@@ -502,7 +543,7 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
     await _send_json(ws, ["EOSE", sub_id])
     logger.info(
         "nip50: sub=%s query=%r observer=%s profile=%s min_rank=%s "
-        "returned=%d emitted=%d",
+        "returned=%d emitted=%d fallback=%s",
         sub_id,
         query,
         observer[:12],
@@ -510,6 +551,7 @@ async def _handle_req(ws: WebSocket, msg: list) -> None:
         min_rank,
         len(results),
         emitted,
+        used_fallback_observer,
     )
 
 

--- a/tests/test_nip50_relay.py
+++ b/tests/test_nip50_relay.py
@@ -648,6 +648,250 @@ def test_cold_start_not_fired_for_default_observer(
     assert calls == []
 
 
+# ---------------------------------------------------------------------------
+# Cold-observer fallback to the default observer's perspective
+# ---------------------------------------------------------------------------
+def _build_fallback_app(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    scored_observers: set[str],
+    result_pubkey: str,
+    observers_queried: list[str],
+    fallback_raises: bool = False,
+    default_observer: str = "e" * 64,
+) -> FastAPI:
+    """App whose Vespa stub only returns hits for observers that have scores.
+
+    Models the real failure mode: an observer with no cell in the
+    ``quality_scores`` tensor scores every document at 0, and the ``min_rank``
+    floor then drops the entire result set — so Vespa hands back an empty list.
+    """
+    from app.routers.nip50 import router as nip50_module
+
+    async def _fake_vespa_search(
+        *,
+        query_text: str,
+        user_pubkey: str,
+        hits: int,
+        include_zero_score_results: bool,
+        ranking_profile: str | None = None,
+        min_rank: float | None = None,
+    ) -> list[dict]:
+        observers_queried.append(user_pubkey)
+        if fallback_raises and user_pubkey == default_observer:
+            raise RuntimeError("vespa exploded on the fallback pass")
+        if user_pubkey in scored_observers:
+            return [{"pubkey": result_pubkey}]
+        return []
+
+    async def _fake_fetch_kind0(authors: list[str]) -> dict[str, dict]:
+        return {
+            pk: _kind0_event(pk, "alice")
+            for pk in authors
+            if pk == result_pubkey
+        }
+
+    async def _noop_provision(_observer: str) -> None:
+        return None
+
+    monkeypatch.setattr(nip50_module, "vespa_search", _fake_vespa_search)
+    monkeypatch.setattr(nip50_module, "_fetch_kind0_events", _fake_fetch_kind0)
+    monkeypatch.setattr(nip50_module, "_maybe_provision_observer", _noop_provision)
+    monkeypatch.setattr(
+        nip50_module, "default_observer_pubkey", lambda: default_observer
+    )
+
+    app = FastAPI()
+    app.include_router(nip50_module.router)
+    return app
+
+
+def test_cold_observer_falls_back_to_default_observer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An observer whose GrapeRank job hasn't landed yet has no scores, so the
+    personalized pass comes back empty. The relay must retry from the default
+    observer's perspective and say so via NOTICE, rather than handing the client
+    a silent empty result set.
+    """
+    pk, cold_observer, default_observer = "a" * 64, "d" * 64, "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers={default_observer},
+        result_pubkey=pk,
+        observers_queried=queried,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"search": f"alice observer:{cold_observer}"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    # Personalized pass first, then the default-observer retry.
+    assert queried == [cold_observer, default_observer]
+
+    events = [f for f in frames if f[0] == "EVENT"]
+    assert [f[2]["pubkey"] for f in events] == [pk]
+
+    notices = [f[1] for f in frames if f[0] == "NOTICE"]
+    assert len(notices) == 1
+    assert cold_observer[:12] in notices[0]
+    assert "default observer" in notices[0]
+
+
+def test_scored_observer_does_not_trigger_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An observer that already has scores must pay exactly one Vespa call and
+    get no NOTICE — the fallback stays off the hot path.
+    """
+    pk, warm_observer, default_observer = "a" * 64, "d" * 64, "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers={warm_observer, default_observer},
+        result_pubkey=pk,
+        observers_queried=queried,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"search": f"alice observer:{warm_observer}"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert queried == [warm_observer]
+    assert [f[1] for f in frames if f[0] == "NOTICE"] == []
+    assert [f[2]["pubkey"] for f in frames if f[0] == "EVENT"] == [pk]
+
+
+def test_genuinely_empty_search_emits_no_fallback_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query that matches nothing for ANY observer still retries once, but
+    must not claim the observer is cold — there is simply nothing to find.
+    """
+    cold_observer, default_observer = "d" * 64, "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers=set(),  # nobody has hits for this query
+        result_pubkey="a" * 64,
+        observers_queried=queried,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"search": f"nomatch observer:{cold_observer}"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert queried == [cold_observer, default_observer]
+    assert [f[1] for f in frames if f[0] == "NOTICE"] == []
+    assert [f for f in frames if f[0] == "EVENT"] == []
+    assert frames[-1] == ["EOSE", "s"]
+
+
+def test_empty_search_without_observer_token_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no ``observer:`` token the search already ran as the default
+    observer, so an empty result is final — retrying would just repeat it.
+    """
+    default_observer = "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers=set(),
+        result_pubkey="a" * 64,
+        observers_queried=queried,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(json.dumps(["REQ", "s", {"search": "nomatch"}]))
+        frames = _drain_until_eose(ws, "s")
+
+    assert queried == [default_observer]
+    assert [f[1] for f in frames if f[0] == "NOTICE"] == []
+
+
+def test_explicit_default_observer_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``observer:<default>`` names the observer we would fall back to, so an
+    empty answer must not trigger an identical second query.
+    """
+    default_observer = "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers=set(),
+        result_pubkey="a" * 64,
+        observers_queried=queried,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(
+                ["REQ", "s", {"search": f"nomatch observer:{default_observer}"}]
+            )
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert queried == [default_observer]
+    assert [f[1] for f in frames if f[0] == "NOTICE"] == []
+
+
+def test_failing_fallback_degrades_to_empty_not_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The personalized pass already succeeded (it was just empty). If the
+    fallback query then fails, the client must still get a clean EOSE — a
+    broken retry must not turn a working search into a backend error.
+    """
+    cold_observer, default_observer = "d" * 64, "e" * 64
+    queried: list[str] = []
+
+    app = _build_fallback_app(
+        monkeypatch,
+        scored_observers={default_observer},
+        result_pubkey="a" * 64,
+        observers_queried=queried,
+        fallback_raises=True,
+        default_observer=default_observer,
+    )
+    client = TestClient(app)
+
+    with client.websocket_connect("/relay") as ws:
+        ws.send_text(
+            json.dumps(["REQ", "s", {"search": f"alice observer:{cold_observer}"}])
+        )
+        frames = _drain_until_eose(ws, "s")
+
+    assert queried == [cold_observer, default_observer]
+    assert [f for f in frames if f[0] == "EVENT"] == []
+    # No "search backend error" NOTICE — the retry failure is logged, not raised.
+    assert [f[1] for f in frames if f[0] == "NOTICE"] == []
+    assert frames[-1] == ["EOSE", "s"]
+
+
 def test_pure_extension_query_returns_eose(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #53.

Targets `reports-and-deletes` rather than `main` because that branch is what staging currently runs — merging here is also how we get a live-Vespa verification (recipe at the bottom).

## The bug

An `observer:<hex>` pubkey whose GrapeRank job hasn't landed yet has no cell in Vespa's `quality_scores` tensor. Every document therefore scores 0 for that observer, the `min_rank` floor (rank>=2 by default) drops the entire result set, and the client gets **zero events and no NOTICE** — on every search, until provisioning completes.

Measured against production, same query throughout:

```
jack (no observer token)          100 hits   ← control
jack observer:<has scores>          3 hits
jack observer:<Jack Dorsey>         0 hits   ← ✗
jack observer:<random valid hex>    0 hits   ← ✗
jack observer:deadbeef            100 hits   ← malformed token, correctly ignored
```

Note the shape: a **malformed** observer token degrades gracefully to full results, while a **well-formed** one for a new pubkey returns nothing. Since plugging in your own npub is the first thing anyone tries with a WoT search relay, the natural read is "this relay is broken."

It also contradicts our own NIP-11 document, which already promises:

> The first time a new observer is used the relay enqueues a GrapeRank computation in the background; **meanwhile the search falls back to the instance's default observer.**

The `_maybe_provision_observer` docstring states the same intent. Provisioning itself fires correctly — it's the behavior *during* the cold window that was wrong.

## The fix

When the personalized pass returns empty **and** an explicit observer was supplied, retry once from the default observer's perspective and emit a NOTICE so the caller can distinguish "warming up" from "no matches."

## Why keyed on an empty result rather than a stored flag

`is_observer_search_available` (migration `911619fd5326`) looks like the natural signal, and it would avoid the second Vespa call. I didn't use it: it lives on `BrainstormNsec` and is only written for observers provisioned through that path, so any observer scored *before* that migration would read `false` despite having real scores — silently downgrading observers that work today. I couldn't verify the backfill state without prod DB access.

Keying off the actual observable can't regress a working observer: it returns hits, so it never takes the second call, and the retry disappears on its own once provisioning lands. The extra round-trip is paid only in the case that currently returns nothing.

**If you can confirm the flag is backfilled for every observer with Vespa cells, gating on it directly would be tighter than this** — happy to switch.

Two deliberate edges:

- **A failing fallback degrades to the original empty answer**, not to an error. The personalized pass already succeeded (it was just empty), so a broken retry must not turn a working search into a backend error.
- **The NOTICE fires only when the retry actually finds something.** A genuinely-empty query returns a bare EOSE exactly as today — telling someone "your observer is cold" when the real answer is "nobody matches that string" would be worse than silence. The tradeoff: a cold observer searching for something nonexistent still gets no signal.

## Tests

Six new tests in `tests/test_nip50_relay.py`. The stub models the real failure mode — Vespa returns `[]` for an observer with no scores.

- `test_cold_observer_falls_back_to_default_observer` — two Vespa calls in order (cold, then default), events emitted, one NOTICE naming the observer
- `test_scored_observer_does_not_trigger_fallback` — exactly one call, no NOTICE
- `test_genuinely_empty_search_emits_no_fallback_notice` — retries, but emits no NOTICE
- `test_empty_search_without_observer_token_does_not_retry`
- `test_explicit_default_observer_does_not_retry`
- `test_failing_fallback_degrades_to_empty_not_error`

The three that assert new behavior **fail against unmodified code** — confirmed by stashing the router change:

```
FAILED test_cold_observer_falls_back_to_default_observer
FAILED test_genuinely_empty_search_emits_no_fallback_notice
FAILED test_failing_fallback_degrades_to_empty_not_error
```

with the captured log showing the bug exactly: `observer=dddddddddddd ... returned=0 emitted=0`. The other three are regression guards that pass both before and after — that's the point of them.

Gates on this branch: **224 passed**, 14 integration deselected. flake8 clean. mypy error count unchanged (14 → 14, all pre-existing). I did **not** run black on the router: the file isn't black-clean on this branch already, and both hunks black wants are in pre-existing code, not in this diff — running it would bury the change in unrelated reformatting.

## Verifying on staging after merge

The unit tests model Vespa's empty-return; nothing here has run against a live Vespa. Staging has two observers that are cold today and return 0 hits — they should start returning the default-observer result set plus a NOTICE:

```bash
# expect: 0 hits before, ~100 hits + NOTICE after
node probe.js "jack observer:82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"  # Jack Dorsey
node probe.js "jack observer:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"  # fiatjaf
```

Minimal client (Node >= 22, no deps — staging serves the relay at `/relay`, not at the root):

```js
const ws = new WebSocket('wss://brainstormserver-staging.nosfabrica.com/relay');
const hits = [];
ws.onopen = () => ws.send(JSON.stringify(
  ['REQ', 'probe', { kinds: [0], search: process.argv[2], limit: 100 }]
));
ws.onmessage = (m) => {
  const x = JSON.parse(m.data);
  if (x[0] === 'EVENT')  hits.push(JSON.parse(x[2].content).name);
  if (x[0] === 'NOTICE') console.log('NOTICE:', x[1]);
  if (x[0] === 'EOSE') { console.log(hits.length, 'hits:', hits.slice(0, 5)); ws.close(); }
};
```

A control that must **not** change: `jack observer:04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9` (Odell) is already warm on staging and returns 100 hits with no NOTICE — it should stay exactly that, taking only one Vespa call.

Server-side, the log line now carries `fallback=True/False` per search, so you can see how often the cold path is being hit.

---

Sibling issue #54 (four smaller doc/UX items from the same audit) is untouched here. Note it has [a correction](https://github.com/NosFabrica/brainstorm_server/issues/54#issuecomment-5050483960) — its item 3 was filed with the wrong trigger.
