### PR TITLE
feat(alerts): add GET /networkAlerts for bad actors in the trust network (read-only)

### DIFF
--- a/app/repos/CLAUDE.md
+++ b/app/repos/CLAUDE.md
@@ -106,6 +106,19 @@ queries:
 - `get_paginated_section_connections(session, pubkey, influence_key, rel_type, direction, limit, cursor_inf, cursor_pk) → (items, next_cursor)` — cursor = `(influence, pubkey)`; ordered influence DESC, pubkey ASC. **Drives `/user/{pubkey}/connections`**.
 - `get_all_section_stats(...)` — one query covering all 6 sections; ~20 % faster than firing them in parallel.
 - `get_user_graph_data(...)` — unpaginated full graph.
+- `get_network_alert_candidates(...)` / `count_above_cutoff_followers_capped(...)` / `count_verified_muters(...)` — the three bounded steps behind **`/networkAlerts`** (orchestrated by `network_alerts_service`). Things to preserve if you touch them:
+  - Candidates are anchored *through* the `REPORTS` edge, never a `:NostrUser` label scan. No index can substitute — the influence/reporter properties are per-observer, so indexing them would mean one index per observer.
+  - `verified_reporter_count >= 3` prefilters before any arithmetic. Valid because `N = 2 + floor(tf/500) >= 2` for everyone.
+  - The capped count's `cap` is **not** an arbitrary page size. A row alerts only when its verified follower count is below `500 * (reporters - 2)`, so a count reaching the cap belongs to a row that fails. That's why a count *below* the cap is exact and safe to publish, and why the service drops rows that hit it.
+  - Step 2 runs for candidates with no stored `trusted_followers_<observer>` — which today is **all** of them, because nothing writes that property. The whole `/networkAlerts` path is read-only against Neo4j. Persisting the property (a one-line addition to `write_neo4j_results.py`) would turn step 2 into a property read, at the cost of a fourth per-observer property; that tradeoff is deliberately a separate change.
+
+**Per-observer node properties** written by `write_neo4j_results.py`, all suffixed
+with the observer's hex pubkey: `influence_`, `hops_`, `trusted_followers_`,
+`trusted_reporters_`. All four are GrapeRank-run-fresh, NOT ingest-fresh — the
+`FOLLOWS`/`MUTES`/`REPORTS` edges update within seconds of a kind 3/10000/1984
+event, but these properties only change when that observer's GrapeRank job
+lands. Prefer an edge match over `hops_<observer> = 1` when you need "does X
+currently follow Y".
 
 Dynamic property access uses `user[$influence_key]` parameterization so
 `influence_<observer>` columns don't get string-interpolated into Cypher.

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -869,3 +869,206 @@ async def get_all_shortest_follow_paths(
     if record is None:
         return [], 0
     return record["paths"], record["path_count"]
+
+
+# ------------------------------ network alerts ------------------------------
+#
+# A network alert is a pubkey carrying more verified reports than its reach
+# justifies. The bar scales with audience size so a large account isn't flagged
+# by the same absolute report count as a small one:
+#
+#     N     = 2 + floor(verified_follower_count / 500)
+#     alert = verified_reporter_count > N
+#
+# The work is split across three bounded queries rather than one big one,
+# because the only expensive input is the verified follower count:
+#
+#   1. get_network_alert_candidates    — property reads only, no edge walks
+#   2. count_above_cutoff_followers_capped — counts followers, capped; used for
+#                                        any candidate with no stored count
+#   3. count_verified_muters           — display-only, over final rows only
+#
+# NOTHING IN THIS MODULE — OR ANYWHERE ELSE IN THE REPO TODAY — WRITES
+# `trusted_followers_<observer>`. Step (1) reads it, but the GrapeRank result
+# writer currently drops that scorecard field, so it is absent on every node and
+# step (2) runs for every candidate. The read is deliberate: persisting the
+# property turns step (2) into a property lookup, which is a follow-up change
+# with its own tradeoffs (extra per-observer property, faster property-key token
+# growth). Until then this path is read-only against Neo4j and pays a bounded
+# follower traversal per candidate instead.
+#
+# Two things keep step (1) off a full label scan:
+#
+#   Anchoring. Candidates are reached *through* the REPORTS edge instead of by
+#   scanning :NostrUser. Only a reported pubkey can clear N >= 2, and the
+#   reported set is orders of magnitude smaller than the node count. (There is
+#   no index that could help instead: the influence/reporter properties are
+#   per-observer, so indexing them would mean one index per observer.)
+#
+#   Prefiltering. The floor term is non-negative, so N >= 2 for everyone and
+#   `verified_reporter_count >= 3` is a superset of every possible alert. It
+#   applies before any arithmetic without dropping a qualifying row.
+#
+# Section membership uses the live (observer)-[:FOLLOWS]->(bob) edge, NOT
+# `hops_<observer> = 1`. The edge is maintained by kind-3 ingest (seconds
+# behind the user's follow list); `hops_` is only rewritten by a GrapeRank run,
+# so it would keep alerting on people the observer already unfollowed. `hops_`
+# is still returned for display, and remains the right input for a future
+# "alert me about pubkeys X hops out" control.
+
+# Grain of the threshold: one extra tolerated report per this many verified
+# followers. Shared with the service so the two can't drift apart.
+FOLLOWERS_PER_EXTRA_REPORT = 500
+
+# Ceiling on candidates pulled back from step (1). Far above any plausible
+# real count — a backstop against a pathological graph, not a paging limit.
+# Callers are expected to log when it bites rather than truncate silently.
+MAX_ALERT_CANDIDATES = 5000
+
+_ALERT_CANDIDATES_QUERY = """
+MATCH (observer:NostrUser {pubkey: $observer_pubkey})
+CALL (observer) {
+    MATCH (:NostrUser)-[:REPORTS]->(bob:NostrUser)
+    WITH DISTINCT observer, bob
+    WHERE coalesce(bob[$trusted_reporters_key], 0) >= 3
+      AND bob.pubkey <> observer.pubkey
+    WITH bob,
+         toInteger(coalesce(bob[$trusted_reporters_key], 0)) AS verified_reporters,
+         bob[$trusted_followers_key] AS stored_followers,
+         bob[$influence_key] AS influence,
+         bob[$hops_key] AS hops,
+         EXISTS { (observer)-[:FOLLOWS]->(bob) } AS is_direct
+    WHERE is_direct OR (influence IS NOT NULL AND influence > $cutoff)
+    RETURN bob.pubkey AS pubkey, verified_reporters, stored_followers,
+           influence, hops, is_direct
+}
+RETURN pubkey, verified_reporters, stored_followers, influence, hops, is_direct
+LIMIT $max_candidates
+"""
+
+
+async def get_network_alert_candidates(
+    session: AsyncNeoDriver,
+    observer_pubkey: str,
+    influence_key: str,
+    hops_key: str,
+    trusted_followers_key: str,
+    trusted_reporters_key: str,
+    cutoff: float,
+    max_candidates: int = MAX_ALERT_CANDIDATES,
+) -> list[dict]:
+    """Pubkeys that could be network alerts, before the report threshold applies.
+
+    Reachability is already decided here (directly followed, or above `cutoff`),
+    but the threshold is NOT — it needs a verified follower count, and
+    `stored_followers` comes back None when this observer has no GrapeRank run
+    carrying `trusted_followers_<observer>` yet. The caller resolves those.
+
+    Touches no follower or muter edges: every value is a property read on the
+    candidate node itself.
+    """
+    result = await session.run(
+        _ALERT_CANDIDATES_QUERY,
+        observer_pubkey=observer_pubkey,
+        influence_key=influence_key,
+        hops_key=hops_key,
+        trusted_followers_key=trusted_followers_key,
+        trusted_reporters_key=trusted_reporters_key,
+        cutoff=cutoff,
+        max_candidates=int(max_candidates),
+    )
+    return [dict(record) async for record in result]
+
+
+async def count_above_cutoff_followers_capped(
+    session: AsyncNeoDriver,
+    pubkeys: list[str],
+    influence_key: str,
+    cutoff: float,
+    cap: int,
+) -> dict[str, int]:
+    """Above-cutoff follower counts, each stopping at `cap`.
+
+    Fallback for candidates with no stored `trusted_followers_<observer>`.
+
+    `cap` is what makes this safe to run on a huge account. A row can only clear
+    the threshold when its verified follower count is below
+    `FOLLOWERS_PER_EXTRA_REPORT * (verified_reporters - 2)`, so counting past
+    that point cannot change any decision. Pass that value as `cap` and read the
+    result as: **count < cap → exact count, row passes; count == cap → the true
+    count is at least `cap`, row fails.** A row that survives therefore always
+    carries a real number, never a truncated one.
+
+    Caveat worth knowing: `cap` bounds the above-cutoff followers *collected*,
+    not the follower edges *scanned*. An account with many followers but few
+    above the cutoff never reaches the cap and still costs a full traversal of
+    its follower edges. The cap helps most where the risk is highest (accounts
+    with a large trusted following) and never hurts.
+
+    Cypher forbids a LIMIT that varies per row, so callers bucket pubkeys by
+    identical `cap` and call this once per bucket; `cap` is interpolated and so
+    is guarded here, at the interpolation site.
+    """
+    if type(cap) is not int or not 1 <= cap <= 10_000_000:
+        raise ValueError(f"cap must be an int in [1, 10000000], got {cap!r}")
+    if not pubkeys:
+        return {}
+
+    query = f"""
+    UNWIND $pubkeys AS pk
+    MATCH (bob:NostrUser {{pubkey: pk}})
+    CALL (bob) {{
+        MATCH (f:NostrUser)-[:FOLLOWS]->(bob)
+        WHERE f[$influence_key] IS NOT NULL
+          AND f[$influence_key] >= $cutoff
+        WITH f
+        LIMIT {cap}
+        RETURN count(f) AS capped_followers
+    }}
+    RETURN pk AS pubkey, capped_followers
+    """
+    result = await session.run(
+        query, pubkeys=pubkeys, influence_key=influence_key, cutoff=cutoff
+    )
+    return {
+        record["pubkey"]: int(record["capped_followers"] or 0)
+        async for record in result
+    }
+
+
+async def count_verified_muters(
+    session: AsyncNeoDriver,
+    pubkeys: list[str],
+    influence_key: str,
+    verified_threshold: float,
+) -> dict[str, int]:
+    """Above-threshold muter counts, keyed by pubkey.
+
+    Display-only — the algorithm never computes a `trusted_muters` scorecard
+    field, so there is nothing stored to read. Never part of the filter, so
+    callers run it last, over the already-limited result rows.
+    """
+    if not pubkeys:
+        return {}
+
+    query = """
+    UNWIND $pubkeys AS pk
+    MATCH (bob:NostrUser {pubkey: pk})
+    CALL (bob) {
+        MATCH (m:NostrUser)-[:MUTES]->(bob)
+        WHERE m[$influence_key] IS NOT NULL
+          AND m[$influence_key] >= $verified_threshold
+        RETURN count(m) AS verified_muters
+    }
+    RETURN pk AS pubkey, verified_muters
+    """
+    result = await session.run(
+        query,
+        pubkeys=pubkeys,
+        influence_key=influence_key,
+        verified_threshold=verified_threshold,
+    )
+    return {
+        record["pubkey"]: int(record["verified_muters"] or 0)
+        async for record in result
+    }

--- a/app/routers/CLAUDE.md
+++ b/app/routers/CLAUDE.md
@@ -14,6 +14,8 @@ here. To wire a brand-new endpoint, add the subdir + register it in this file.
 |---|---|---|
 | `/health` | `app/api.py:164` | Liveness (returns `1`) |
 | `/whitelisted/{observer_pubkey}` | `router.py:75-94` | Trusted-pubkey list for an observer; `threshold` query param (default 0.02) |
+| `/shortestPath` | `graph/router.py` | Shortest directed FOLLOWS path(s) between two pubkeys |
+| `/networkAlerts` | `network_alerts/router.py` | Pubkeys carrying more verified reports than their reach justifies, split into direct-follows / extended-network |
 
 ## Subdirs (by URL prefix)
 

--- a/app/routers/network_alerts/router.py
+++ b/app/routers/network_alerts/router.py
@@ -1,0 +1,55 @@
+"""Network Alerts panel (Brainstorm dashboard).
+
+Mounted at root so the path is exactly /networkAlerts — like /shortestPath,
+this is a graph-wide question parameterized by an observer, not a lookup on the
+/user/{pubkey} resource.
+
+The observer is an explicit query param rather than the authenticated caller:
+the dashboard renders the House point of view by passing the House pubkey, and
+the endpoint has no reason to know which pubkey that is. Public read, matching
+the auth posture of the other read-only graph traversals — every score it
+returns is already public via /user/{pubkey}/overview.
+"""
+
+from fastapi import APIRouter, Query
+
+from app.schemas.request_response_schemas import GetNetworkAlertsResponse
+from app.services import network_alerts_service
+from app.services.network_alerts_service import (
+    DEFAULT_ALERT_LIMIT,
+    MAX_ALERT_LIMIT,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    path="/networkAlerts",
+    summary=(
+        "Pubkeys in the observer's network carrying more verified reports "
+        "than their reach justifies"
+    ),
+)
+async def get_network_alerts_endpoint(
+    observer: str = Query(
+        ...,
+        description=(
+            "Observer pubkey (hex or npub). All trust scores are reported from "
+            "this perspective. Pass the House pubkey for the House view."
+        ),
+    ),
+    limit: int = Query(
+        default=DEFAULT_ALERT_LIMIT,
+        ge=1,
+        le=MAX_ALERT_LIMIT,
+        description=(
+            "Max rows per section. Each section is capped independently; the "
+            "response flags which ones were truncated."
+        ),
+    ),
+) -> GetNetworkAlertsResponse:
+    data = await network_alerts_service.get_network_alerts_for_observer(
+        observer_raw=observer,
+        limit=limit,
+    )
+    return GetNetworkAlertsResponse(data=data)

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -9,6 +9,7 @@ from app.routers.admin.router import router as admin_router
 from app.routers.auth_challenge.router import router as auth_challenge_router
 from app.routers.graph.router import router as graph_router
 from app.routers.graperank.router import router as graperank_router
+from app.routers.network_alerts.router import router as network_alerts_router
 from app.routers.nip50.router import router as nip50_router
 from app.routers.open_ranking.router import router as open_ranking_router
 from app.routers.search.router import router as search_router
@@ -44,6 +45,13 @@ router.include_router(
 router.include_router(
     router=graph_router,
     tags=["graph"],
+)
+
+# Network Alerts panel. Mounted at root alongside /shortestPath — an
+# observer-parameterized question about the graph, not a /user sub-resource.
+router.include_router(
+    router=network_alerts_router,
+    tags=["network-alerts"],
 )
 
 ADMIN_ROUTER_PREFIX = "/admin"

--- a/app/schemas/request_response_schemas.py
+++ b/app/schemas/request_response_schemas.py
@@ -213,3 +213,54 @@ class ShortestPathData(BaseModel):
 
 class GetShortestPathResponse(SuccessfulResponseDataSchema):
     data: ShortestPathData
+
+
+class NetworkAlertItem(BaseModel):
+    """One flagged pubkey in a network-alert section.
+
+    Carries every trust score the panel needs so the front end doesn't have to
+    follow up with /user/{pubkey}/overview per row. Kind-0 profile data is
+    deliberately NOT here — the front end already resolves that separately.
+
+    `verifiedReporterCount` and `reporterThreshold` are returned as a pair so
+    the UI can explain *why* a row is flagged ("7 verified reports against a
+    threshold of 4") rather than restating the rule client-side.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pubkey: str
+    influence: float | None
+    hops: int | None
+    verified_follower_count: int = Field(serialization_alias="verifiedFollowerCount")
+    verified_muter_count: int = Field(serialization_alias="verifiedMuterCount")
+    verified_reporter_count: int = Field(serialization_alias="verifiedReporterCount")
+    # The N this row was tested against: 2 + floor(verifiedFollowerCount / 500).
+    reporter_threshold: int = Field(serialization_alias="reporterThreshold")
+
+
+class NetworkAlertsData(BaseModel):
+    """Payload of GET /networkAlerts.
+
+    A pubkey qualifying for both sections appears only in `direct_follows` —
+    the observer's own follow is the more actionable signal, and duplicating
+    the row would double-count one bad actor in the panel.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    observer_pubkey: str = Field(serialization_alias="observerPubkey")
+    direct_follows: list[NetworkAlertItem] = Field(serialization_alias="directFollows")
+    extended_network: list[NetworkAlertItem] = Field(
+        serialization_alias="extendedNetwork"
+    )
+    # True when a section hit `limit` and more alerts exist behind it. Lets the
+    # panel show "showing first N" instead of implying the list is exhaustive.
+    direct_follows_truncated: bool = Field(serialization_alias="directFollowsTruncated")
+    extended_network_truncated: bool = Field(
+        serialization_alias="extendedNetworkTruncated"
+    )
+
+
+class GetNetworkAlertsResponse(SuccessfulResponseDataSchema):
+    data: NetworkAlertsData

--- a/app/services/CLAUDE.md
+++ b/app/services/CLAUDE.md
@@ -17,6 +17,7 @@ publishing — and routers just thin-wrap them.
 | `graperank_preset_service.py` | 109 | Builtin presets (DEFAULT/PERMISSIVE/RESTRICTIVE) get/set + history; bridges camelCase API ↔ snake_case columns. |
 | `assistant_profile_service.py` | 107 | Publish a kind-0 profile event for the assistant pubkey. Pure Nostr-side; no DB. |
 | `nsec_encryption_service.py` | 210 | Background rotation of `BrainstormNsec.encrypted_nsec`: scan rows, decrypt-old/encrypt-new, write back. Idempotent and resumable. |
+| `network_alerts_service.py` | 118 | `/networkAlerts`: resolves the observer (hex or npub), builds the per-observer property keys, maps graph rows → panel payload. Neo4j-only, no SQL. |
 
 ## Conventions
 

--- a/app/services/network_alerts_service.py
+++ b/app/services/network_alerts_service.py
@@ -1,0 +1,266 @@
+"""Network alerts: bad actors who gained a following inside the trust network.
+
+v1 of the Brainstorm dashboard "Network Alerts" panel. Answers one question for
+an observer (Alice): which pubkeys in my network carry more verified reports
+than their reach justifies?
+
+The panel has two sections and this service maps 1:1 onto them:
+
+- **Direct follows** — Alice follows them herself. Most actionable: she can
+  unfollow directly.
+- **Extended network** — she doesn't follow them, but they clear the GrapeRank
+  cutoff from her perspective, i.e. someone she trusts vouches for them.
+
+A pubkey qualifying for both is reported only under direct follows.
+
+The threshold needs a verified follower count, and today nothing stores one:
+the GrapeRank algorithm computes `trusted_followers` but the Neo4j result
+writer drops it. So this service counts above-cutoff followers from the graph,
+bounded so a popular account can't dominate the response — see
+`_resolve_follower_counts`.
+
+It still *reads* `trusted_followers_<observer>` and prefers it when present.
+That read is inert until something persists the property; it exists so that
+change stays a one-line addition to the result writer rather than a rewrite
+here. Everything this service does against Neo4j is a read.
+
+Coalescing a missing count to 0 was the obvious alternative and is wrong: it
+pins N at 2 for everyone, which over-alerts on exactly the large accounts the
+scaling exists to protect.
+"""
+
+import math
+from collections import defaultdict
+
+from fastapi import HTTPException, status
+from nostr_sdk import PublicKey
+
+from app.core.loggr import loggr
+from app.core.tier_thresholds import DEFAULT_VERIFIED_THRESHOLD
+from app.neo4j_db.driver import driver as neo4j_driver
+from app.repos.user_repo import (
+    FOLLOWERS_PER_EXTRA_REPORT,
+    MAX_ALERT_CANDIDATES,
+    count_above_cutoff_followers_capped,
+    count_verified_muters,
+    get_network_alert_candidates,
+)
+from app.schemas.request_response_schemas import (
+    NetworkAlertItem,
+    NetworkAlertsData,
+)
+
+logger = loggr.get_logger(__name__)
+
+# Influence at or above which a pubkey counts as part of the observer's trust
+# network. Same line the whitelist and the /connections tiering use, so the
+# extended-network section matches what the rest of the product calls "trusted".
+NETWORK_ALERT_CUTOFF = DEFAULT_VERIFIED_THRESHOLD
+
+# Floor of the scaled threshold: everyone tolerates this many verified reports
+# before any follower-count allowance applies.
+BASE_REPORTER_THRESHOLD = 2
+
+DEFAULT_ALERT_LIMIT = 100
+MAX_ALERT_LIMIT = 500
+
+
+def _resolve_pubkey_or_400(value: str, param_name: str) -> str:
+    """Hex or npub in, canonical hex out; anything unparseable is a 400."""
+    try:
+        return PublicKey.parse(value).to_hex()
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{param_name} is not a valid hex pubkey or npub",
+        )
+
+
+def _safe_float(value) -> float | None:
+    """Neo4j can hand back inf/nan for stale or unbacked influence properties,
+    and json.dumps rejects both. Same coercion /connections applies."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isinf(f) or math.isnan(f):
+        return None
+    return f
+
+
+def _safe_int(value) -> int | None:
+    if value is None:
+        return None
+    f = _safe_float(value)
+    return None if f is None else int(f)
+
+
+def reporter_threshold_for(verified_followers: int) -> int:
+    """N = 2 + floor(verified_followers / 500)."""
+    return BASE_REPORTER_THRESHOLD + verified_followers // FOLLOWERS_PER_EXTRA_REPORT
+
+
+def follower_count_cap_for(verified_reporters: int) -> int:
+    """Point past which counting a candidate's verified followers is pointless.
+
+    A row alerts when ``verified_reporters > 2 + floor(vfc / 500)``, which
+    rearranges to ``vfc < 500 * (verified_reporters - 2)``. Once that many
+    verified followers have been counted the row cannot alert, whatever the
+    true total is — so the count stops there.
+
+    Always >= 500, because candidates are prefiltered to
+    ``verified_reporters >= 3``.
+    """
+    return FOLLOWERS_PER_EXTRA_REPORT * (verified_reporters - BASE_REPORTER_THRESHOLD)
+
+
+async def _resolve_follower_counts(
+    session,
+    candidates: list[dict],
+    influence_key: str,
+) -> dict[str, int]:
+    """Verified follower count per candidate pubkey, for rows that can alert.
+
+    Stored value wins, but nothing writes `trusted_followers_<observer>` today,
+    so in practice every candidate takes the counted path below. The count is
+    capped at `follower_count_cap_for(...)`. Cypher can't vary a LIMIT per row,
+    so candidates are bucketed by identical cap and each bucket is one query —
+    typically one or two, since the cap only varies with the reporter count.
+
+    A pubkey is absent from the result when it hit its cap: that means its true
+    count is at or above the cap, so it cannot alert and the caller drops it.
+    Every pubkey present therefore carries an exact count, never a truncated
+    one — which is why `verifiedFollowerCount` is always a real number on the
+    wire.
+    """
+    resolved: dict[str, int] = {}
+    by_cap: dict[int, list[str]] = defaultdict(list)
+
+    for row in candidates:
+        stored = _safe_int(row.get("stored_followers"))
+        if stored is not None:
+            resolved[row["pubkey"]] = stored
+        else:
+            by_cap[follower_count_cap_for(int(row["verified_reporters"]))].append(
+                row["pubkey"]
+            )
+
+    if by_cap:
+        logger.info(
+            "network_alerts: %d candidate(s) missing trusted_followers; "
+            "counting from the graph across %d capped bucket(s)",
+            sum(len(v) for v in by_cap.values()),
+            len(by_cap),
+        )
+
+    for cap, pubkeys in by_cap.items():
+        counts = await count_above_cutoff_followers_capped(
+            session=session,
+            pubkeys=pubkeys,
+            influence_key=influence_key,
+            cutoff=NETWORK_ALERT_CUTOFF,
+            cap=cap,
+        )
+        for pubkey in pubkeys:
+            count = counts.get(pubkey, 0)
+            # == cap means the count was truncated: true value >= cap, so the
+            # row cannot clear its threshold. Leaving it out drops it.
+            if count < cap:
+                resolved[pubkey] = count
+
+    return resolved
+
+
+def _to_item(
+    row: dict, verified_followers: int, verified_muters: int
+) -> NetworkAlertItem:
+    return NetworkAlertItem(
+        pubkey=row["pubkey"],
+        influence=_safe_float(row.get("influence")),
+        hops=_safe_int(row.get("hops")),
+        verified_follower_count=verified_followers,
+        verified_muter_count=verified_muters,
+        verified_reporter_count=int(row["verified_reporters"]),
+        reporter_threshold=reporter_threshold_for(verified_followers),
+    )
+
+
+async def get_network_alerts_for_observer(
+    observer_raw: str,
+    limit: int = DEFAULT_ALERT_LIMIT,
+) -> NetworkAlertsData:
+    """Both alert sections from the observer's perspective.
+
+    `observer_raw` is hex or npub. The observer is whoever the caller names —
+    the front end passes the House pubkey when it wants the House point of
+    view, so this service has no notion of who the House is.
+    """
+    observer = _resolve_pubkey_or_400(observer_raw, "observer")
+    influence_key = f"influence_{observer}"
+
+    async with neo4j_driver.session() as session:
+        candidates = await get_network_alert_candidates(
+            session=session,
+            observer_pubkey=observer,
+            influence_key=influence_key,
+            hops_key=f"hops_{observer}",
+            trusted_followers_key=f"trusted_followers_{observer}",
+            trusted_reporters_key=f"trusted_reporters_{observer}",
+            cutoff=NETWORK_ALERT_CUTOFF,
+        )
+        if len(candidates) >= MAX_ALERT_CANDIDATES:
+            # Never truncate quietly — a capped candidate set means the sections
+            # below are incomplete in a way the truncation flags don't express.
+            logger.warning(
+                "network_alerts: candidate ceiling (%d) reached for observer %s; "
+                "results may be incomplete",
+                MAX_ALERT_CANDIDATES,
+                observer[:12],
+            )
+
+        follower_counts = await _resolve_follower_counts(
+            session, candidates, influence_key
+        )
+
+        # Threshold test. Candidates missing from follower_counts hit their cap
+        # and are already known not to clear it.
+        alerts = [
+            (row, follower_counts[row["pubkey"]])
+            for row in candidates
+            if row["pubkey"] in follower_counts
+            and int(row["verified_reporters"])
+            > reporter_threshold_for(follower_counts[row["pubkey"]])
+        ]
+
+        # The `is_direct` split is what makes the sections disjoint, so a pubkey
+        # qualifying for both is reported once, under direct follows.
+        direct = [(r, f) for r, f in alerts if r["is_direct"]]
+        extended = [(r, f) for r, f in alerts if not r["is_direct"]]
+
+        direct.sort(key=lambda rf: (-int(rf[0]["verified_reporters"]), rf[0]["pubkey"]))
+        extended.sort(
+            key=lambda rf: (-(_safe_float(rf[0]["influence"]) or 0.0), rf[0]["pubkey"])
+        )
+
+        direct_page, extended_page = direct[:limit], extended[:limit]
+
+        muters = await count_verified_muters(
+            session=session,
+            pubkeys=[r["pubkey"] for r, _ in direct_page + extended_page],
+            influence_key=influence_key,
+            verified_threshold=DEFAULT_VERIFIED_THRESHOLD,
+        )
+
+    return NetworkAlertsData(
+        observer_pubkey=observer,
+        direct_follows=[
+            _to_item(r, f, muters.get(r["pubkey"], 0)) for r, f in direct_page
+        ],
+        extended_network=[
+            _to_item(r, f, muters.get(r["pubkey"], 0)) for r, f in extended_page
+        ],
+        direct_follows_truncated=len(direct) > limit,
+        extended_network_truncated=len(extended) > limit,
+    )

--- a/tests/integration/test_network_alerts_integration.py
+++ b/tests/integration/test_network_alerts_integration.py
@@ -1,0 +1,399 @@
+"""Integration tests for GET /networkAlerts against a real Neo4j.
+
+Requires Neo4j reachable at ``settings.neo4j_db_url``. Run explicitly with::
+
+    poetry run pytest tests/integration/test_network_alerts_integration.py -m integration
+
+These cover what the mocked suite structurally cannot: that the Cypher parses,
+that REPORTS anchoring and live-edge section membership behave as intended, and
+that the capped follower count truncates where it should.
+
+Fixture graph — all per-observer properties are set from alice's perspective
+(``influence_<alice>``, ``trusted_followers_<alice>``, ...). ``tf`` is the
+stored verified-follower count, and ``None`` means the property is absent, which
+is what forces the counted fallback. ``N`` is ``2 + floor(tf / 500)``; a row
+alerts when its verified reporter count is strictly greater than N.
+
+    name                  follows?  influence  tf     tr   N   alerts?
+    direct_flagged        yes       0.001      0      5    2   direct
+    direct_boundary       yes       0.400      0      2    2   no  (2 > 2 false)
+    direct_just_over      yes       0.400      0      3    2   direct
+    ext_flagged           no        0.500      0      4    2   extended
+    ext_below_cutoff      no        0.001      0      9    2   no  (under cutoff)
+    ext_scaled_blocked    no        0.500      1000   4    4   no  (4 > 4 false)
+    ext_scaled_flagged    no        0.500      1000   5    4   extended
+    both_sections         yes       0.900      0      6    2   direct ONLY
+    stale_no_report_edge  yes       0.400      0      7    2   no  (no REPORTS edge)
+    fallback_counted      yes       0.400      None   3    2   direct, tf counted
+    alice (self)          --        0.990      0      9    2   no  (self-excluded)
+
+``direct_flagged`` sits *below* the cutoff on purpose: the direct section is
+defined by the follow edge alone, with no influence requirement.
+``stale_no_report_edge`` carries a reporter count with no surviving REPORTS
+edge — the shape left behind when reports are retracted (kind 5) before the
+next GrapeRank run rewrites the property. ``fallback_counted`` is seeded with
+three above-cutoff followers and one below, so the counted value is a known 3.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from neo4j import AsyncGraphDatabase
+from nostr_sdk import Keys
+
+from app.api import app
+from app.core.config import settings
+from app.repos.user_repo import count_above_cutoff_followers_capped
+
+pytestmark = pytest.mark.integration
+
+# influence, stored trusted_followers (None = absent), trusted_reporters,
+# alice-follows, has-report-edge
+_FIXTURE = {
+    "direct_flagged": (0.001, 0, 5, True, True),
+    "direct_boundary": (0.400, 0, 2, True, True),
+    "direct_just_over": (0.400, 0, 3, True, True),
+    "ext_flagged": (0.500, 0, 4, False, True),
+    "ext_below_cutoff": (0.001, 0, 9, False, True),
+    "ext_scaled_blocked": (0.500, 1000, 4, False, True),
+    "ext_scaled_flagged": (0.500, 1000, 5, False, True),
+    "both_sections": (0.900, 0, 6, True, True),
+    "stale_no_report_edge": (0.400, 0, 7, True, False),
+    "fallback_counted": (0.400, None, 3, True, True),
+}
+
+# Followers seeded onto `fallback_counted`: three above the 0.02 cutoff, one
+# below. The counted verified-follower count must therefore come back as 3.
+_FALLBACK_FOLLOWERS = [("f_hi1", 0.30), ("f_hi2", 0.20), ("f_hi3", 0.10)]
+_FALLBACK_WEAK_FOLLOWERS = [("f_lo1", 0.001)]
+
+
+def _fresh_driver():
+    return AsyncGraphDatabase.driver(
+        settings.neo4j_db_url,
+        auth=(settings.neo4j_db_username, settings.neo4j_db_password),
+    )
+
+
+@pytest.fixture(scope="module")
+def graph():
+    """Seed the fixture graph; yield {name: hex_pubkey}; clean up after."""
+    follower_names = [n for n, _ in _FALLBACK_FOLLOWERS + _FALLBACK_WEAK_FOLLOWERS]
+    names = (
+        list(_FIXTURE)
+        + follower_names
+        + ["alice", "reporter", "muter_verified", "muter_weak"]
+    )
+    pks = {name: Keys.generate().public_key().to_hex() for name in names}
+    alice = pks["alice"]
+
+    inf_key = f"influence_{alice}"
+    hops_key = f"hops_{alice}"
+    tf_key = f"trusted_followers_{alice}"
+    tr_key = f"trusted_reporters_{alice}"
+
+    async def _seed():
+        driver = _fresh_driver()
+        try:
+            async with driver.session() as s:
+                for name, (inf, tf, tr, followed, reported) in _FIXTURE.items():
+                    # tf is set only when not None — absent means "no GrapeRank
+                    # run has written trusted_followers for this observer yet".
+                    tf_clause = f", n.`{tf_key}` = $tf" if tf is not None else ""
+                    await s.run(
+                        f"""
+                        MERGE (n:NostrUser {{pubkey: $pk}})
+                        SET n.`{inf_key}` = $inf,
+                            n.`{hops_key}` = 2,
+                            n.`{tr_key}` = $tr
+                            {tf_clause}
+                        """,
+                        pk=pks[name],
+                        inf=inf,
+                        tf=tf,
+                        tr=tr,
+                    )
+                    if followed:
+                        await s.run(
+                            """
+                            MERGE (a:NostrUser {pubkey: $alice})
+                            MERGE (b:NostrUser {pubkey: $pk})
+                            MERGE (a)-[:FOLLOWS]->(b)
+                            """,
+                            alice=alice,
+                            pk=pks[name],
+                        )
+                    if reported:
+                        await s.run(
+                            """
+                            MERGE (r:NostrUser {pubkey: $reporter})
+                            MERGE (b:NostrUser {pubkey: $pk})
+                            MERGE (r)-[:REPORTS]->(b)
+                            """,
+                            reporter=pks["reporter"],
+                            pk=pks[name],
+                        )
+
+                # Followers of `fallback_counted`, straddling the cutoff.
+                for fname, finf in _FALLBACK_FOLLOWERS + _FALLBACK_WEAK_FOLLOWERS:
+                    await s.run(
+                        f"""
+                        MERGE (f:NostrUser {{pubkey: $fpk}})
+                        SET f.`{inf_key}` = $finf
+                        MERGE (b:NostrUser {{pubkey: $target}})
+                        MERGE (f)-[:FOLLOWS]->(b)
+                        """,
+                        fpk=pks[fname],
+                        finf=finf,
+                        target=pks["fallback_counted"],
+                    )
+
+                # Alice would clear the bar herself if she weren't excluded.
+                await s.run(
+                    f"""
+                    MERGE (a:NostrUser {{pubkey: $alice}})
+                    SET a.`{inf_key}` = 0.99, a.`{tf_key}` = 0, a.`{tr_key}` = 9
+                    MERGE (r:NostrUser {{pubkey: $reporter}})
+                    MERGE (r)-[:REPORTS]->(a)
+                    """,
+                    alice=alice,
+                    reporter=pks["reporter"],
+                )
+
+                # Two muters on direct_flagged: only the above-cutoff one counts.
+                await s.run(
+                    f"""
+                    MERGE (mv:NostrUser {{pubkey: $mv}}) SET mv.`{inf_key}` = 0.60
+                    MERGE (mw:NostrUser {{pubkey: $mw}}) SET mw.`{inf_key}` = 0.001
+                    MERGE (b:NostrUser {{pubkey: $target}})
+                    MERGE (mv)-[:MUTES]->(b)
+                    MERGE (mw)-[:MUTES]->(b)
+                    """,
+                    mv=pks["muter_verified"],
+                    mw=pks["muter_weak"],
+                    target=pks["direct_flagged"],
+                )
+        finally:
+            await driver.close()
+
+    async def _cleanup():
+        driver = _fresh_driver()
+        try:
+            async with driver.session() as s:
+                await s.run(
+                    "MATCH (n:NostrUser) WHERE n.pubkey IN $pks DETACH DELETE n",
+                    pks=list(pks.values()),
+                )
+        finally:
+            await driver.close()
+
+    asyncio.run(_seed())
+    yield pks
+    asyncio.run(_cleanup())
+
+
+@asynccontextmanager
+async def _async_client():
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def _fetch(observer: str, **params) -> dict:
+    async def _go():
+        async with _async_client() as client:
+            resp = await client.get(
+                "/networkAlerts", params={"observer": observer, **params}
+            )
+            assert resp.status_code == 200, resp.text
+            return resp.json()["data"]
+
+    return asyncio.run(_go())
+
+
+def _names(data: dict, section: str, graph: dict) -> set[str]:
+    by_pubkey = {v: k for k, v in graph.items()}
+    return {by_pubkey[item["pubkey"]] for item in data[section]}
+
+
+def _row(data: dict, graph: dict, name: str) -> dict:
+    everything = data["directFollows"] + data["extendedNetwork"]
+    return next(i for i in everything if i["pubkey"] == graph[name])
+
+
+def test_direct_section_membership(graph):
+    data = _fetch(graph["alice"])
+
+    assert _names(data, "directFollows", graph) == {
+        "direct_flagged",
+        "direct_just_over",
+        "both_sections",
+        "fallback_counted",
+    }
+
+
+def test_extended_section_membership(graph):
+    data = _fetch(graph["alice"])
+
+    assert _names(data, "extendedNetwork", graph) == {
+        "ext_flagged",
+        "ext_scaled_flagged",
+    }
+
+
+def test_sections_are_disjoint(graph):
+    """A pubkey qualifying for both is reported under direct follows only."""
+    data = _fetch(graph["alice"])
+
+    direct = _names(data, "directFollows", graph)
+    extended = _names(data, "extendedNetwork", graph)
+    assert "both_sections" in direct
+    assert not direct & extended
+
+
+def test_threshold_scales_with_verified_followers(graph):
+    """1000 verified followers lifts N from 2 to 4, so 4 reports no longer alert."""
+    data = _fetch(graph["alice"])
+
+    everything = {i["pubkey"] for i in data["directFollows"] + data["extendedNetwork"]}
+    assert graph["ext_scaled_blocked"] not in everything
+
+    flagged = _row(data, graph, "ext_scaled_flagged")
+    assert flagged["reporterThreshold"] == 4
+    assert flagged["verifiedReporterCount"] == 5
+    assert flagged["verifiedFollowerCount"] == 1000
+
+
+def test_report_count_must_strictly_exceed_threshold(graph):
+    """direct_boundary has exactly N=2 reports, so it is not an alert."""
+    data = _fetch(graph["alice"])
+
+    assert "direct_boundary" not in _names(data, "directFollows", graph)
+    assert "direct_just_over" in _names(data, "directFollows", graph)
+
+
+def test_direct_section_ignores_influence(graph):
+    """A directly-followed pubkey alerts even below the trust cutoff."""
+    data = _fetch(graph["alice"])
+
+    assert _row(data, graph, "direct_flagged")["influence"] < 0.02
+
+
+def test_below_cutoff_and_unfollowed_is_not_an_alert(graph):
+    data = _fetch(graph["alice"])
+
+    all_names = _names(data, "directFollows", graph) | _names(
+        data, "extendedNetwork", graph
+    )
+    assert "ext_below_cutoff" not in all_names
+
+
+def test_stale_reporter_count_without_report_edge_is_ignored(graph):
+    """Anchoring on REPORTS means a retracted report stops alerting immediately,
+    without waiting for the next GrapeRank run to rewrite the property."""
+    data = _fetch(graph["alice"])
+
+    assert "stale_no_report_edge" not in _names(data, "directFollows", graph)
+
+
+def test_observer_is_never_alerted_about_themselves(graph):
+    data = _fetch(graph["alice"])
+
+    pubkeys = {i["pubkey"] for i in data["directFollows"] + data["extendedNetwork"]}
+    assert graph["alice"] not in pubkeys
+
+
+def test_verified_muter_count_excludes_below_cutoff_muters(graph):
+    """direct_flagged has 2 muters; only the above-cutoff one is counted."""
+    data = _fetch(graph["alice"])
+
+    assert _row(data, graph, "direct_flagged")["verifiedMuterCount"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Counted-fallback path (no stored trusted_followers_<observer>)
+# ---------------------------------------------------------------------------
+def test_missing_stored_count_is_counted_from_the_graph(graph):
+    """fallback_counted has no stored property; 3 of its 4 followers clear the
+    cutoff, so the endpoint must report exactly 3 — not 0, and not 4."""
+    data = _fetch(graph["alice"])
+
+    row = _row(data, graph, "fallback_counted")
+    assert row["verifiedFollowerCount"] == 3
+    assert row["reporterThreshold"] == 2
+
+
+def test_capped_count_stops_at_the_cap(graph):
+    """The LIMIT is what bounds a scan on a huge account — verify it truncates.
+
+    Below the cap the count is exact; at the cap it stops, which is the signal
+    the service uses to drop a row rather than publish a truncated number.
+    """
+
+    async def _go():
+        driver = _fresh_driver()
+        try:
+            async with driver.session() as s:
+                inf_key = f"influence_{graph['alice']}"
+                exact = await count_above_cutoff_followers_capped(
+                    session=s,
+                    pubkeys=[graph["fallback_counted"]],
+                    influence_key=inf_key,
+                    cutoff=0.02,
+                    cap=10,
+                )
+                truncated = await count_above_cutoff_followers_capped(
+                    session=s,
+                    pubkeys=[graph["fallback_counted"]],
+                    influence_key=inf_key,
+                    cutoff=0.02,
+                    cap=2,
+                )
+                return exact, truncated
+        finally:
+            await driver.close()
+
+    exact, truncated = asyncio.run(_go())
+
+    assert exact[graph["fallback_counted"]] == 3
+    assert truncated[graph["fallback_counted"]] == 2
+
+
+def test_capped_count_rejects_a_nonsense_cap(graph):
+    """`cap` is interpolated into the Cypher, so it's guarded at that site."""
+
+    async def _go():
+        driver = _fresh_driver()
+        try:
+            async with driver.session() as s:
+                await count_above_cutoff_followers_capped(
+                    session=s,
+                    pubkeys=[graph["fallback_counted"]],
+                    influence_key=f"influence_{graph['alice']}",
+                    cutoff=0.02,
+                    cap="1 RETURN 1 //",
+                )
+        finally:
+            await driver.close()
+
+    with pytest.raises(ValueError):
+        asyncio.run(_go())
+
+
+def test_limit_caps_each_section_and_flags_truncation(graph):
+    data = _fetch(graph["alice"], limit=1)
+
+    assert len(data["directFollows"]) == 1
+    assert len(data["extendedNetwork"]) == 1
+    assert data["directFollowsTruncated"] is True
+    assert data["extendedNetworkTruncated"] is True
+
+
+def test_unknown_observer_returns_empty_sections(graph):
+    """A pubkey absent from the graph has no perspective — not an error."""
+    data = _fetch(Keys.generate().public_key().to_hex())
+
+    assert data["directFollows"] == []
+    assert data["extendedNetwork"] == []

--- a/tests/test_network_alerts.py
+++ b/tests/test_network_alerts.py
@@ -1,0 +1,393 @@
+"""Fast-suite tests for GET /networkAlerts.
+
+Covers everything that needs no graph backend: input validation, npub
+resolution, the stored-vs-counted follower-count hybrid, threshold arithmetic,
+section split, ordering, limits, and inf/nan coercion.
+
+The Cypher itself — REPORTS anchoring, the capped LIMIT, and live-edge section
+membership — is exercised against a real Neo4j in
+tests/integration/test_network_alerts_integration.py.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nostr_sdk import Keys
+
+from app.services.network_alerts_service import (
+    follower_count_cap_for,
+    reporter_threshold_for,
+)
+
+
+def _get(client, params: dict):
+    return client.get("/networkAlerts", params=params)
+
+
+def _pk() -> str:
+    return Keys.generate().public_key().to_hex()
+
+
+def _candidate(pubkey: str, **overrides) -> dict:
+    """A row as get_network_alert_candidates returns it."""
+    row = {
+        "pubkey": pubkey,
+        "verified_reporters": 5,
+        "stored_followers": 0,
+        "influence": 0.5,
+        "hops": 1,
+        "is_direct": True,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture
+def mock_graph(monkeypatch):
+    """Patch the three repo calls + the Neo4j session opener.
+
+    Returns a dict of the AsyncMocks so a test can set candidates and, where it
+    matters, the capped-count and muter-count responses.
+    """
+    mocks = {
+        "candidates": AsyncMock(return_value=[]),
+        "capped": AsyncMock(return_value={}),
+        "muters": AsyncMock(return_value={}),
+    }
+    monkeypatch.setattr(
+        "app.services.network_alerts_service.get_network_alert_candidates",
+        mocks["candidates"],
+    )
+    monkeypatch.setattr(
+        "app.services.network_alerts_service.count_above_cutoff_followers_capped",
+        mocks["capped"],
+    )
+    monkeypatch.setattr(
+        "app.services.network_alerts_service.count_verified_muters", mocks["muters"]
+    )
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield AsyncMock()
+
+    fake_driver = MagicMock()
+    fake_driver.session = lambda: _fake_session()
+    monkeypatch.setattr("app.services.network_alerts_service.neo4j_driver", fake_driver)
+    return mocks
+
+
+# ---------------------------------------------------------------------------
+# Threshold arithmetic
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "followers,expected",
+    [(0, 2), (499, 2), (500, 3), (999, 3), (1000, 4), (2500, 7), (8600, 19)],
+)
+def test_reporter_threshold_scales_per_500_followers(followers, expected):
+    assert reporter_threshold_for(followers) == expected
+
+
+@pytest.mark.parametrize("verified_reporters", range(3, 40))
+def test_cap_is_exactly_the_point_where_a_row_can_no_longer_alert(
+    verified_reporters,
+):
+    """The cap's correctness invariant, stated directly.
+
+    A row alerts iff its verified follower count is strictly below the cap. So
+    a count that reaches the cap can be abandoned — it can only belong to a row
+    that fails — and a count below the cap is both exact and passing.
+    """
+    cap = follower_count_cap_for(verified_reporters)
+
+    assert verified_reporters > reporter_threshold_for(cap - 1)
+    assert not verified_reporters > reporter_threshold_for(cap)
+
+
+def test_cap_is_never_below_one_bucket():
+    """Candidates are prefiltered to >= 3 reporters, so the cap can't be 0."""
+    assert follower_count_cap_for(3) == 500
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not-a-pubkey",
+        "nprofile1qqstest",  # other NIP-19 forms are rejected
+        "8f3fbb5129dcb9194c02b67c1b41a3f60dd369663f53499b2b3c72a73c6fa9",  # 62 chars
+        "npub1invalidinvalidinvalid",
+    ],
+)
+def test_invalid_observer_is_400(client, mock_graph, bad):
+    resp = _get(client, {"observer": bad})
+
+    assert resp.status_code == 400
+    assert "observer" in resp.json()["detail"]
+
+
+def test_observer_is_required(client, mock_graph):
+    assert _get(client, {}).status_code == 422
+
+
+def test_accepts_npub_and_echoes_canonical_hex(client, mock_graph):
+    keys = Keys.generate()
+
+    resp = _get(client, {"observer": keys.public_key().to_bech32()})
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["observerPubkey"] == keys.public_key().to_hex()
+
+
+def test_observer_drives_the_property_keys(client, mock_graph):
+    observer = _pk()
+
+    _get(client, {"observer": observer})
+
+    kwargs = mock_graph["candidates"].await_args.kwargs
+    assert kwargs["observer_pubkey"] == observer
+    assert kwargs["influence_key"] == f"influence_{observer}"
+    assert kwargs["hops_key"] == f"hops_{observer}"
+    assert kwargs["trusted_followers_key"] == f"trusted_followers_{observer}"
+    assert kwargs["trusted_reporters_key"] == f"trusted_reporters_{observer}"
+
+
+@pytest.mark.parametrize("bad_limit", [0, -1, 501])
+def test_limit_out_of_range_is_422(client, mock_graph, bad_limit):
+    assert _get(client, {"observer": _pk(), "limit": bad_limit}).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Stored count vs counted fallback
+# ---------------------------------------------------------------------------
+def test_stored_follower_count_skips_the_graph_scan(client, mock_graph):
+    bob = _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(bob, stored_followers=1200, verified_reporters=5)
+    ]
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    mock_graph["capped"].assert_not_awaited()
+    item = data["directFollows"][0]
+    assert item["verifiedFollowerCount"] == 1200
+    assert item["reporterThreshold"] == 4
+
+
+def test_missing_stored_count_falls_back_to_a_capped_scan(client, mock_graph):
+    bob = _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(bob, stored_followers=None, verified_reporters=5)
+    ]
+    # Cap for 5 reporters is 500 * 3 = 1500; came back under it, so it's exact.
+    mock_graph["capped"].return_value = {bob: 900}
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert mock_graph["capped"].await_args.kwargs["cap"] == 1500
+    assert mock_graph["capped"].await_args.kwargs["pubkeys"] == [bob]
+    item = data["directFollows"][0]
+    assert item["verifiedFollowerCount"] == 900
+    assert item["reporterThreshold"] == 3
+
+
+def test_count_that_reaches_the_cap_is_dropped_not_reported(client, mock_graph):
+    """Hitting the cap means the true count is >= cap, so the row can't alert.
+
+    Reporting it would mean publishing a truncated follower count as if it were
+    real; dropping it is both correct and keeps the payload honest.
+    """
+    bob = _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(bob, stored_followers=None, verified_reporters=5)
+    ]
+    mock_graph["capped"].return_value = {bob: 1500}  # == cap
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert data["directFollows"] == []
+    assert data["extendedNetwork"] == []
+
+
+def test_fallback_buckets_candidates_by_cap(client, mock_graph):
+    """One query per distinct cap — Cypher can't vary a LIMIT per row."""
+    low, high = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(low, stored_followers=None, verified_reporters=3),
+        _candidate(high, stored_followers=None, verified_reporters=10),
+    ]
+    mock_graph["capped"].return_value = {}
+
+    _get(client, {"observer": _pk()})
+
+    caps = {c.kwargs["cap"] for c in mock_graph["capped"].await_args_list}
+    assert caps == {500, 4000}
+
+
+def test_stored_and_missing_counts_mix_in_one_response(client, mock_graph):
+    stored, counted = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(stored, stored_followers=600, verified_reporters=9),
+        _candidate(counted, stored_followers=None, verified_reporters=9),
+    ]
+    mock_graph["capped"].return_value = {counted: 100}
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    # Only the one lacking a stored value was scanned.
+    assert mock_graph["capped"].await_args.kwargs["pubkeys"] == [counted]
+    by_pubkey = {i["pubkey"]: i for i in data["directFollows"]}
+    assert by_pubkey[stored]["verifiedFollowerCount"] == 600
+    assert by_pubkey[counted]["verifiedFollowerCount"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Threshold application, sections, ordering
+# ---------------------------------------------------------------------------
+def test_report_count_must_strictly_exceed_threshold(client, mock_graph):
+    at, over = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(at, stored_followers=0, verified_reporters=2),
+        _candidate(over, stored_followers=0, verified_reporters=3),
+    ]
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert [i["pubkey"] for i in data["directFollows"]] == [over]
+
+
+def test_sections_split_on_is_direct(client, mock_graph):
+    direct, extended = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(direct, stored_followers=0, is_direct=True),
+        _candidate(extended, stored_followers=0, is_direct=False, hops=3),
+    ]
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert [i["pubkey"] for i in data["directFollows"]] == [direct]
+    assert [i["pubkey"] for i in data["extendedNetwork"]] == [extended]
+
+
+def test_direct_section_orders_by_report_count_desc(client, mock_graph):
+    few, many = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(few, stored_followers=0, verified_reporters=4),
+        _candidate(many, stored_followers=0, verified_reporters=12),
+    ]
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert [i["pubkey"] for i in data["directFollows"]] == [many, few]
+
+
+def test_extended_section_orders_by_influence_desc(client, mock_graph):
+    low, high = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(low, stored_followers=0, is_direct=False, influence=0.05),
+        _candidate(high, stored_followers=0, is_direct=False, influence=0.60),
+    ]
+
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert [i["pubkey"] for i in data["extendedNetwork"]] == [high, low]
+
+
+def test_item_carries_every_score_the_panel_needs(client, mock_graph):
+    bob = _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(
+            bob, stored_followers=1200, verified_reporters=9, influence=0.31, hops=1
+        )
+    ]
+    mock_graph["muters"].return_value = {bob: 7}
+
+    item = _get(client, {"observer": _pk()}).json()["data"]["directFollows"][0]
+
+    assert item == {
+        "pubkey": bob,
+        "influence": 0.31,
+        "hops": 1,
+        "verifiedFollowerCount": 1200,
+        "verifiedMuterCount": 7,
+        "verifiedReporterCount": 9,
+        # Returned alongside the count so the UI can say *why* it's flagged.
+        "reporterThreshold": 4,
+    }
+
+
+def test_muters_are_counted_only_for_returned_rows(client, mock_graph):
+    kept, dropped = _pk(), _pk()
+    mock_graph["candidates"].return_value = [
+        _candidate(kept, stored_followers=0, verified_reporters=5),
+        # Below threshold — never reaches the payload, so never counted.
+        _candidate(dropped, stored_followers=0, verified_reporters=2),
+    ]
+
+    _get(client, {"observer": _pk()})
+
+    assert mock_graph["muters"].await_args.kwargs["pubkeys"] == [kept]
+
+
+# ---------------------------------------------------------------------------
+# Limits and edge cases
+# ---------------------------------------------------------------------------
+def test_limit_caps_each_section_independently(client, mock_graph):
+    mock_graph["candidates"].return_value = [
+        _candidate(_pk(), stored_followers=0) for _ in range(3)
+    ] + [_candidate(_pk(), stored_followers=0, is_direct=False)]
+
+    data = _get(client, {"observer": _pk(), "limit": 2}).json()["data"]
+
+    assert len(data["directFollows"]) == 2
+    assert data["directFollowsTruncated"] is True
+    assert len(data["extendedNetwork"]) == 1
+    assert data["extendedNetworkTruncated"] is False
+
+
+def test_section_filled_exactly_to_limit_is_not_truncated(client, mock_graph):
+    """Truncation is 'more exist behind this', not 'the page is full'."""
+    mock_graph["candidates"].return_value = [
+        _candidate(_pk(), stored_followers=0) for _ in range(2)
+    ]
+
+    data = _get(client, {"observer": _pk(), "limit": 2}).json()["data"]
+
+    assert len(data["directFollows"]) == 2
+    assert data["directFollowsTruncated"] is False
+
+
+def test_no_candidates_returns_empty_sections(client, mock_graph):
+    data = _get(client, {"observer": _pk()}).json()["data"]
+
+    assert data["directFollows"] == []
+    assert data["extendedNetwork"] == []
+    assert data["directFollowsTruncated"] is False
+    assert data["extendedNetworkTruncated"] is False
+
+
+@pytest.mark.parametrize("bad_influence", [float("inf"), float("-inf"), float("nan")])
+def test_unserializable_influence_becomes_null(client, mock_graph, bad_influence):
+    """Neo4j hands back inf/nan for stale properties; json.dumps rejects both."""
+    mock_graph["candidates"].return_value = [
+        _candidate(_pk(), stored_followers=0, influence=bad_influence)
+    ]
+
+    resp = _get(client, {"observer": _pk()})
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["directFollows"][0]["influence"] is None
+
+
+def test_missing_hops_is_tolerated(client, mock_graph):
+    """hops_<observer> is absent until the observer's first GrapeRank run."""
+    mock_graph["candidates"].return_value = [
+        _candidate(_pk(), stored_followers=0, hops=None)
+    ]
+
+    item = _get(client, {"observer": _pk()}).json()["data"]["directFollows"][0]
+
+    assert item["hops"] is None
+    assert item["verifiedReporterCount"] == 5


### PR DESCRIPTION
Backend for the dashboard's **Network Alerts** panel, which is currently greyed out as "Coming Soon". v1 of the API only — no UI in this PR.

Targets `reports-and-deletes` rather than `main` because that branch is what staging currently runs. It also happens to be the right base on the merits: this feature leans on the REPORTS graph that branch maintains, and inherits a nice property from the kind-5 handling (see *Retracted reports* below).

## What it answers

For an observer (Alice): **which pubkeys in my network have accumulated more verified reports than their reach justifies?** The point is to surface bad actors who have gained a following — either Alice's own, or that of someone she trusts — so she can unfollow or report.

The bar scales with audience size, so a large account isn't flagged by the same absolute report count as a small one:

```
N     = 2 + floor(verified_follower_count / 500)
alert = verified_reporter_count > N
```

Two sections, matching the panel:

- **Direct follows** — Alice follows them herself. No influence requirement; the follow edge alone qualifies.
- **Extended network** — she doesn't follow them, but they clear the 0.02 GrapeRank cutoff from her perspective, i.e. someone she trusts vouches for them.

A pubkey qualifying for both appears only under direct follows — that's the more actionable signal, and duplicating it would double-count one bad actor in the panel.

## API

```
GET /networkAlerts?observer=<hex|npub>&limit=100
```

Public read, mounted at root next to `/shortestPath` — an observer-parameterized question about the graph, not a `/user/{pubkey}` sub-resource. Every score it returns is already public via `/user/{pubkey}/overview`.

The observer is an explicit param rather than the authenticated caller, so the front end gets the House view by passing the House pubkey; the endpoint has no notion of who the House is.

```json
{ "code": 200, "data": {
  "observerPubkey": "…",
  "directFollows": [
    { "pubkey": "a1f4…9c2e", "influence": 0.0089, "hops": 1,
      "verifiedFollowerCount": 340, "verifiedMuterCount": 12,
      "verifiedReporterCount": 9, "reporterThreshold": 2 }
  ],
  "extendedNetwork": [ … ],
  "directFollowsTruncated": false,
  "extendedNetworkTruncated": false } }
```

`reporterThreshold` is the N that row was tested against, returned alongside the count so the UI can say *why* something is flagged — "9 verified reports against a threshold of 4" — rather than restating the rule client-side. Kind-0 profile data is deliberately absent; the front end already resolves that separately.

## Decisions worth reviewing

### Direct follows match the live edge, not `hops_<observer> = 1`

The original spec said hops = 1, and the reasoning was that Neo4j is never more than ~60s behind Alice's kind-3 list. That's true of the **FOLLOWS edge**, which kind-3 ingest maintains — but `hops_<observer>` is written only by `write_neo4j_results.py`, so it's a snapshot from Alice's last GrapeRank run. Hours old, possibly more.

Matching `(alice)-[:FOLLOWS]->(bob)` is fresher, exact, and cheaper than a property read. Concretely: if Alice unfollowed Bob this morning, `hops_ = 1` still says she follows him and we'd keep alerting on him.

`hops_` is still returned for display, and remains the right input for the "alert me about pubkeys X hops out" slider if we build it.

### Candidates are anchored through the REPORTS edge

Not a `:NostrUser` label scan. Only a reported pubkey can ever clear N ≥ 2, and the reported set is orders of magnitude smaller than the node count.

No index could substitute here — `influence_*` / `trusted_reporters_*` are per-observer properties, so indexing them would mean one index per observer. Worth keeping in mind generally: the only Neo4j index we have is the `nostr_user_pubkey` constraint.

### `verified_reporter_count >= 3` prefilters before any arithmetic

The floor term is non-negative, so N ≥ 2 for everyone, so every possible alert has ≥ 3 verified reporters. Cheap superset filter that provably can't drop a qualifying row.

### Retracted reports stop alerting immediately

Falls out of the anchoring, and is specific to this base branch. When a report is deleted via kind 5, `reports-and-deletes` removes the edge, but `trusted_reporters_<observer>` stays stale until the next GrapeRank run. Because candidates are reached *through* the edge, the alert disappears with the edge rather than lingering. There's an integration test pinning this.

### This PR does not write to Neo4j

Worth stating plainly, because the obvious implementation of this feature does. Every Cypher statement on the request path is `MATCH` / `WITH` / `RETURN`:

- no property written
- no node or relationship created or deleted
- no index, constraint, or schema change
- no migration (Alembic is Postgres-only and untouched)

The only `MERGE` / `SET` / `DETACH DELETE` in the diff is in the integration-test fixture, which seeds freshly-generated keys and tears them down, and only runs under `-m integration`.

One deliberate loose end: step 1 reads `trusted_followers_<observer>` and prefers it when present, but **nothing writes that property**, so the read is inert and the counted path always runs. It's there so that persisting it later is a one-line change to the result writer rather than a rewrite here. That follow-up is #59 — deliberately separate, because it buys latency at the cost of a fourth per-observer property.

### Follower count: counted from the graph, with a bounded cap

There is no stored follower count to read (see above), and naively coalescing to 0 would pin N at 2 for everyone — over-alerting on exactly the large accounts the scaling exists to protect. So we count above-cutoff followers from the graph, capped at `500 * (reporters - 2)`.

The cap isn't an arbitrary page size, and the arithmetic makes it clean. A row alerts iff `vfc < 500 * (reporters - 2)`, which **is** the cap. So:

- **count < cap** → the followers were exhausted before the limit → count is **exact**, row passes
- **count == cap** → true count ≥ cap → row **fails**, and gets dropped

The cap only ever truncates rows that were about to be discarded, so every row on the wire carries a real follower count — never a truncated one. That invariant is asserted directly across reporter counts 3–39, so retuning the 500 constant or the base threshold fails loudly instead of silently publishing garbage.

Cypher can't vary a `LIMIT` per row, so candidates are bucketed by identical cap — typically one or two buckets.

**The honest limit:** the cap bounds the above-cutoff followers *collected*, not the follower edges *scanned*. An account with many followers but few above the cutoff never reaches the cap and still costs a full traversal. It helps most where the risk is highest (large trusted followings) and never hurts, but it is not a hard ceiling on work.

## Query shape

Three bounded queries rather than one broad one:

| Step | Cost | When |
|---|---|---|
| `get_network_alert_candidates` | property reads only, no edge walks | always |
| `count_above_cutoff_followers_capped` | capped follower traversal, bucketed | every candidate (nothing stores the count yet) |
| `count_verified_muters` | over final rows only (≤ 2 × limit) | always |

Two or three round-trips per request. Step 2 runs for every candidate today; #59 would reduce it to a property read.

Verified muter count has no stored counterpart — the algorithm has no `trusted_muters` scorecard field — but it's display-only and never part of the filter, so it's counted last over the already-limited rows.

## Testing — please read before merging

**73 fast tests** (mocked; input validation, threshold arithmetic, the stored/counted hybrid, cap semantics, sections, ordering, limits, inf/nan coercion). Full suite is 249 passing, no regressions. flake8 clean on all new code.

**15 integration tests are written but have never been run.** No Neo4j was reachable in the authoring environment. That means **the Cypher in this PR has never executed against a database.** I reviewed it clause-by-clause against `get_paginated_flagged_connections` and that caught one real bug — `WITH … WHERE … ORDER BY … LIMIT` is invalid, since a `WITH` binds `WHERE` after `ORDER BY`/`LIMIT` — but careful reading isn't execution.

Please run these before merging:

```
pytest tests/integration/test_network_alerts_integration.py -m integration
```

They seed a synthetic graph with fresh keys and tear it down after. Coverage includes the scaled threshold, the strict `>` boundary, section disjointness, self-exclusion, the retracted-report case, the counted fallback, and a direct check that `cap=10` returns 3 while `cap=2` returns 2 — the `LIMIT` semantics the whole design rests on.

## Latency: the thing to watch

Every candidate takes the counted path, which is a traversal of that pubkey's follower edges. The cap keeps it bounded — but it bounds the followers *collected*, not the edges *scanned*, so a flagged account with a large follower list is the worst case and one of them can dominate the response.

That is the main reason to land this before #59: it lets us measure the real cost against the real graph, with no change to stored data and nothing to undo if the numbers are bad. `PROFILE` on the candidate query plus the `db hits` on the property-access operator will say directly whether the follower scan or the per-observer property chain dominates.

## Open questions

1. **Path naming.** I used `/networkAlerts` to match the repo's camelCase convention (`/shortestPath`, `/authChallenge`, `/isSearchObserver`). Say the word if you'd rather have `/network-alerts`.
2. **Auth posture.** Public read, matching the other read-only graph traversals. Reasonable given every value is already exposed via `/user/{pubkey}/overview`, but flagging it since this endpoint makes "who is sketchy in your network" a single call for any pubkey.
3. **The inert stored-value read.** Step 1 reads a property nothing writes. I'd keep it — it makes #59 a one-line change and costs one null property read — but it's fair to call it dead code and ask for it to go until the follow-up lands.
4. **`MAX_ALERT_CANDIDATES = 5000`** is a backstop against a pathological graph, not a paging limit, and logs a warning when it bites. Happy to change the number or drop it if it seems arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
