### PR TITLE
perf(alerts): persist trusted_followers_<observer> to skip the follower scan

### DIFF
--- a/app/message_queue_tasks/write_neo4j_results.py
+++ b/app/message_queue_tasks/write_neo4j_results.py
@@ -44,11 +44,18 @@ async def process_neo4j_write_message(message: dict):
         await db.commit()
 
     async def process_batch(batch):
+        # `trusted_followers` is the observee's verified-follower count as the
+        # algorithm computed it (followers above `verifiedFollowersInfluenceCutoff`
+        # — see GrapeRankAlgorithm.java). It's persisted because the network-alert
+        # threshold scales with it (N = 2 + floor(verified_followers / 500)), and
+        # recounting above-cutoff followers per candidate at query time is a scan
+        # over every follower edge. Written here, it's a property read instead.
         query = f"""
         UNWIND $rows AS row
         MATCH (n:NostrUser {{pubkey: row.observee}})
         SET n.influence_{observer} = row.influence,
             n.hops_{observer} = row.hops,
+            n.trusted_followers_{observer} = row.trusted_followers,
             n.trusted_reporters_{observer} = row.trusted_reporters
         """
         async with neo4j_driver.session() as session:

--- a/app/repos/CLAUDE.md
+++ b/app/repos/CLAUDE.md
@@ -110,7 +110,7 @@ queries:
   - Candidates are anchored *through* the `REPORTS` edge, never a `:NostrUser` label scan. No index can substitute — the influence/reporter properties are per-observer, so indexing them would mean one index per observer.
   - `verified_reporter_count >= 3` prefilters before any arithmetic. Valid because `N = 2 + floor(tf/500) >= 2` for everyone.
   - The capped count's `cap` is **not** an arbitrary page size. A row alerts only when its verified follower count is below `500 * (reporters - 2)`, so a count reaching the cap belongs to a row that fails. That's why a count *below* the cap is exact and safe to publish, and why the service drops rows that hit it.
-  - Step 2 runs for candidates with no stored `trusted_followers_<observer>` — which today is **all** of them, because nothing writes that property. The whole `/networkAlerts` path is read-only against Neo4j. Persisting the property (a one-line addition to `write_neo4j_results.py`) would turn step 2 into a property read, at the cost of a fourth per-observer property; that tradeoff is deliberately a separate change.
+  - Step 2 runs only for candidates with no stored `trusted_followers_<observer>`, and goes quiet as observers backfill. `write_neo4j_results.py` persists that property, making it a **fourth** per-observer property — note the cost: Neo4j walks a linked list of property records to resolve a key, and every distinct property *name* permanently consumes a global property-key token that is never reclaimed. Both scale with observer count.
 
 **Per-observer node properties** written by `write_neo4j_results.py`, all suffixed
 with the observer's hex pubkey: `influence_`, `hops_`, `trusted_followers_`,

--- a/app/repos/user_repo.py
+++ b/app/repos/user_repo.py
@@ -888,14 +888,14 @@ async def get_all_shortest_follow_paths(
 #                                        any candidate with no stored count
 #   3. count_verified_muters           — display-only, over final rows only
 #
-# NOTHING IN THIS MODULE — OR ANYWHERE ELSE IN THE REPO TODAY — WRITES
-# `trusted_followers_<observer>`. Step (1) reads it, but the GrapeRank result
-# writer currently drops that scorecard field, so it is absent on every node and
-# step (2) runs for every candidate. The read is deliberate: persisting the
-# property turns step (2) into a property lookup, which is a follow-up change
-# with its own tradeoffs (extra per-observer property, faster property-key token
-# growth). Until then this path is read-only against Neo4j and pays a bounded
-# follower traversal per candidate instead.
+# Steady state is (1) + (3): `write_neo4j_results.py` persists
+# `trusted_followers_<observer>`, so step (1) reads the count straight off the
+# node. Step (2) is the fallback for any observer whose run carrying that
+# property hasn't landed yet, and goes quiet as they backfill.
+#
+# The read path here works either way — it prefers the stored value and counts
+# only when it's absent — so reverting the writer degrades performance without
+# breaking correctness.
 #
 # Two things keep step (1) off a full label scan:
 #

--- a/app/services/network_alerts_service.py
+++ b/app/services/network_alerts_service.py
@@ -13,16 +13,11 @@ The panel has two sections and this service maps 1:1 onto them:
 
 A pubkey qualifying for both is reported only under direct follows.
 
-The threshold needs a verified follower count, and today nothing stores one:
-the GrapeRank algorithm computes `trusted_followers` but the Neo4j result
-writer drops it. So this service counts above-cutoff followers from the graph,
-bounded so a popular account can't dominate the response — see
-`_resolve_follower_counts`.
-
-It still *reads* `trusted_followers_<observer>` and prefers it when present.
-That read is inert until something persists the property; it exists so that
-change stays a one-line addition to the result writer rather than a rewrite
-here. Everything this service does against Neo4j is a read.
+The threshold needs a verified follower count. It normally comes straight off
+the node — `trusted_followers_<observer>`, written by the GrapeRank result
+writer — but it is absent for any observer whose first run carrying that
+property hasn't landed. Those rows are counted from the graph instead, bounded
+so a popular account can't dominate the response. See `_resolve_follower_counts`.
 
 Coalescing a missing count to 0 was the obvious alternative and is wrong: it
 pins N at 2 for everyone, which over-alerts on exactly the large accounts the
@@ -123,10 +118,9 @@ async def _resolve_follower_counts(
 ) -> dict[str, int]:
     """Verified follower count per candidate pubkey, for rows that can alert.
 
-    Stored value wins, but nothing writes `trusted_followers_<observer>` today,
-    so in practice every candidate takes the counted path below. The count is
-    capped at `follower_count_cap_for(...)`. Cypher can't vary a LIMIT per row,
-    so candidates are bucketed by identical cap and each bucket is one query —
+    Stored value wins. Anything missing it is counted from the graph, capped at
+    `follower_count_cap_for(...)`. Cypher can't vary a LIMIT per row, so
+    candidates are bucketed by identical cap and each bucket is one query —
     typically one or two, since the cap only varies with the reporter count.
 
     A pubkey is absent from the result when it hit its cap: that means its true


### PR DESCRIPTION
**Stacked on #58 — review and merge that first.** Until it lands, GitHub will show this PR's diff as *both* changesets; the incremental change here is one `SET` clause plus doc updates. Nothing here changes what the API returns.

This is the deliberate tradeoff we split out of #58: **a faster endpoint, paid for with a new Neo4j property and the costs that come with it.** Merging #58 alone is a perfectly valid end state. This one is worth taking only if the measured latency there justifies it.

## What it buys

The alert threshold is `N = 2 + floor(verified_follower_count / 500)`. The algorithm already computes that count — `GrapeRankAlgorithm.java`, followers above `verifiedFollowersInfluenceCutoff` — but the Neo4j result writer drops the field. So today the endpoint counts above-cutoff followers by traversing follower edges on every request.

This adds the field to the `SET` clause the writer already runs, turning that traversal into a property read:

```diff
  SET n.influence_{observer} = row.influence,
      n.hops_{observer} = row.hops,
+     n.trusted_followers_{observer} = row.trusted_followers,
      n.trusted_reporters_{observer} = row.trusted_reporters
```

The traversal it removes is capped at `500 * (reporters - 2)`, but that cap bounds the followers **collected**, not the edges **scanned**. An account with many followers but few above the cutoff never reaches the cap and pays a full traversal — so a single popular flagged account can dominate response time. That is the cost this removes.

## What it costs

### A fourth per-observer property

Every `NostrUser` node already carries `influence_<observer>`, `hops_<observer>` and `trusted_reporters_<observer>`. This makes four.

Neo4j stores node properties as a **linked list of property records** and resolves a key by walking that chain. So this slows down *every* per-observer property read across the codebase — `/user/{pubkey}/overview`, `/connections`, `/stats`, the NIP-50 relay — not just this feature's. The effect scales with observer count, which grows without bound.

### Property-key tokens are global, permanent, and never reclaimed

Neo4j maps property *names* to global token IDs. Because these names embed the observer pubkey, every new observer permanently consumes tokens — and this takes the rate from 3 to 4 per observer.

They are never garbage-collected. Deleting every node carrying a dead observer's properties does not reclaim its tokens, and `clean_observer_orphans.py` cleans the Vespa and relay sinks but does not touch Neo4j properties. The token store is memory-resident, so this is a slow monotonic tax rather than a cliff — but it is not reversible by deleting data.

To see where you actually stand before merging:

```
CALL db.propertyKeys() YIELD propertyKey
WITH CASE
  WHEN propertyKey STARTS WITH 'influence_'         THEN 'influence'
  WHEN propertyKey STARTS WITH 'hops_'              THEN 'hops'
  WHEN propertyKey STARTS WITH 'trusted_followers_' THEN 'trusted_followers'
  WHEN propertyKey STARTS WITH 'trusted_reporters_' THEN 'trusted_reporters'
  ELSE 'other' END AS kind
RETURN kind, count(*) ORDER BY count(*) DESC
```

The `influence` row is your observer count; multiply by one to get what this adds.

### It writes on every run, not just full recalculations

Worth being explicit, since it determines the write volume. The algorithm pushes each finished job to `write_neo4j_message_queue` (`Main.java`), and the consumer writes **every scorecard in the run** — this is not incremental. Unlike the Nostr and Vespa sinks, `write_neo4j_results.py` ignores `changedScorePubkeys`. It also doesn't check `success` (that guard is commented out), so failed runs write too.

So this lands on every completed run from every trigger: the periodic cronjob, `POST /user/graperank`, admin triggers, brainstorm-pubkey creation, the scheduler, and NIP-50 cold-start provisioning. Marginal cost per run is small — same query, one more assignment per row — but it is a full rewrite each time, not a delta.

## Reversibility

Asymmetric, and worth knowing before merging rather than after.

**The code reverts cleanly.** The read path prefers the stored value and falls back to counting when it's absent, so reverting this commit degrades performance and changes nothing else. No API change, no correctness change.

**The data doesn't.** Properties already written stay on the nodes as orphans, and the property-key tokens stay in the store permanently. Nothing reads them, nothing breaks — but there is no tooling here to remove them, and no way to reclaim the tokens.

## Rollout

Until an observer has a run carrying the new property, their candidates still take the counted path — so this is a gradual improvement, not a step change. Triggering a run for the House pubkey (and any observer used in a demo) is the fastest way to see the difference.

## Testing

Same suites as #58: 249 fast tests pass, and the stored-value path is covered (`test_stored_follower_count_skips_the_graph_scan` asserts the follower scan is not called when the property is present).

**The integration suite still has not been run** — no Neo4j was reachable in the authoring environment. That caveat carries over from #58 and applies to both.

## The honest summary

If `/networkAlerts` latency is acceptable without this, don't merge it. The endpoint is correct either way, and this trades a permanent, partly-irreversible cost in the graph for a request-time win. Worth taking only with numbers in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
