### PR TITLE
Make prefix and fuzzy name matching actually work

### DIFF
--- a/app/core/vespa.py
+++ b/app/core/vespa.py
@@ -45,8 +45,14 @@ PROFILE_FIELDS = (
 )
 
 # Maps the doc.sd match_quality() name tier (1..4) to a human label surfaced in
-# the search response as `_match_tier`. Tier 0 resolves to "affiliation" (bio or
-# website domain match) or "gram" (trigram/recall noise). See §10 / §11.
+# the search response as `_match_tier`. That ladder is inert (§11.1), so in
+# practice the tier comes from the matchCount-based signals below, in doc.sd's
+# ranking order:
+#   name        exact whole-token hit on name/display_name
+#   near        prefix or typo hit, via the name_parts/name_tokens attributes
+#   identity    nip05/lud16 (IDF-scored — the "primal" dilution)
+#   affiliation about/website
+#   gram        trigram recall (name-side is off; about_gram only)
 _MATCH_TIERS = {4: "exact", 3: "prefix", 2: "1-typo", 1: "2-typo"}
 
 # Rank-profile names defined in the Vespa schema (doc.sd). The DEFAULT is
@@ -642,6 +648,7 @@ async def search(
         mq = mf.get("match_quality")
         fields["_match_quality"] = mq
         fields["_identity_text"] = mf.get("identity_text")
+        fields["_near_name_match"] = mf.get("near_name_match")
         fields["_text_score"] = mf.get("text_score")
         fields["_wot_mult"] = mf.get("wot_mult")
         if mf:
@@ -649,12 +656,22 @@ async def search(
                 fields["_match_tier"] = _MATCH_TIERS.get(int(mq), str(mq))
             elif mf.get("name_match"):
                 fields["_match_tier"] = "name"
+            elif mf.get("near_name_match"):
+                # Prefix or typo hit on name/display_name, via doc.sd's
+                # name_parts/name_tokens attributes. Without this branch every
+                # such hit reports as "gram" — the tier it used to arrive
+                # through — which reads as noise in the inspector and in
+                # tools/rank_ab.py when it is in fact a real name match.
+                fields["_match_tier"] = "near"
             elif mf.get("identity_match"):
                 fields["_match_tier"] = "identity"
             elif mf.get("has_token_match"):
                 # older profiles fold nip05/lud16 into has_token_match
                 fields["_match_tier"] = "name"
-            elif mf.get("affiliation_match"):
+            elif mf.get("affiliation_match_text") or mf.get("affiliation_match"):
+                # affiliation_match_text is the default profile's gate (keyed on
+                # name_match); affiliation_match is the older has_token_match one,
+                # still used by relevance()/rank_*. Accept either.
                 fields["_match_tier"] = "affiliation"
             else:
                 fields["_match_tier"] = "gram"

--- a/app/core/vespa_query.py
+++ b/app/core/vespa_query.py
@@ -25,6 +25,77 @@ _PRIMARY_FIELDS = ("name", "display_name", "nip05", "lud16")
 _AFFILIATION_FIELDS = ("about", "website")
 _SEARCH_FIELDS = ("name", "display_name", "about", "nip05", "lud16", "website")
 
+# Attribute fields in doc.sd that prefix/fuzzy terms are matched against. Both
+# are built from name + display_name, at two different granularities, and BOTH
+# are needed:
+#
+#   name_parts   split at every word START, including inside a compound name
+#                (camelCase + any non-alphanumeric run). This is what makes
+#                "meme" find "BitcoinMemeTreasury" and "lover" find
+#                "CoffeeLover" — splitting on spaces alone found neither.
+#   name_tokens  whole space-delimited tokens. Required because name_parts alone
+#                REGRESSES the compound-prefix case: "VitorPamplona" splits to
+#                [vitor, pamplona] and "vitorp" prefixes neither.
+#
+# They are OR'd, so a word matching either granularity is a near hit.
+_NEAR_FIELDS = ("name_parts", "name_tokens")
+
+# Both matchers need TWO things that were missing until 2026-07-30 (verified
+# against a scratch Vespa; see the note above `field name` in doc.sd):
+#
+#   1. a DIRECT term. `userInput()` silently drops `prefix`/`fuzzy` annotations
+#      from the terms it builds, so `({defaultIndex:"name",prefix:true}
+#      userInput(@w))` ran for months as a plain exact match, with no error.
+#   2. an ATTRIBUTE field. Against an `index` field the direct form is rejected
+#      outright ("'name' is not an attribute field: Prefix matching is not
+#      supported"); fuzzy() returns HTTP 400.
+#
+# Cause 1 masked cause 2 by turning it into a no-op, which is why "Ode" and
+# "Odel" could never find "ODELL" and nothing ever surfaced an error.
+#
+# Fields without an attribute sibling (about/website/nip05/lud16) stay exact-only:
+# a prefix or fuzzy term against them is an ERROR, not a no-op.
+
+# Minimum word length for a prefix clause. Prefix is a posting-list scan over
+# every term sharing the prefix, so 1-2 Latin characters would sweep a large
+# slice of a multi-million-doc corpus for no precision gain. 3 also matches the
+# trigram floor, so nothing that previously worked stops working.
+MIN_PREFIX_LEN = 3
+
+# ...but 3 is a LATIN heuristic. A 2-character CJK query ("中村") is as specific
+# as a 5-6 character Latin one, and a flat 3 made such names unfindable — the
+# whole point of the unicode-aware split is undone if the query can't reach them.
+# Any word carrying a non-ASCII character gets the lower floor; those dictionaries
+# are sparse enough that a 2-character prefix stays cheap.
+MIN_PREFIX_LEN_NON_ASCII = 2
+
+
+def _min_prefix_len(word: str) -> int:
+    return MIN_PREFIX_LEN if word.isascii() else MIN_PREFIX_LEN_NON_ASCII
+
+# Trigram recall on the NAME fields — OFF since 2026-07-30.
+#
+# `_gram_clause` ORs every trigram of a word against name_gram/display_name_gram,
+# so ANY doc sharing a single 3-character sequence matched. It was the one
+# matcher with NO bound on how different a hit could be, and no typo budget can
+# constrain it. Measured on a scratch Vespa:
+#     grams "ode"  -> model, code, ODELL, Odessa, Ode
+#     grams "odel" -> model, code, CITADELDISPATCH, ODELL, Odessa, Ode
+# "model" and "CITADELDISPATCH" are not within ANY edit budget of the query.
+#
+# It existed to paper over prefix/fuzzy being broken. Now that both work, real
+# prefix + a length-gated typo budget cover the same recall with a defined bound.
+#
+# TRADE-OFF: this drops INFIX matching. Prefix is anchored at the start and fuzzy
+# keeps prefixLength:2, so "dell" no longer finds "ODELL". That is the price of
+# every hit being within a stated edit distance. Flip this back to True to trade
+# the bound for that recall — the name_gram fields stay in doc.sd either way, and
+# primary_text()'s bm25(name_gram) term simply reads 0 while this is off.
+#
+# about_gram is deliberately NOT affected: bio search has no prefix/fuzzy path,
+# and its clause ANDs every trigram of the word (far tighter than this OR).
+NAME_GRAM_RECALL = False
+
 
 def _field_role(field: str) -> str:
     if field in _PRIMARY_FIELDS:
@@ -49,69 +120,125 @@ def _gram_clause(text: str, gram_field: str, gram_size: int = 3) -> str:
     )
 
 
+# Minimum trigrams before the about_gram clause is worth emitting. A word of
+# length L yields L-2 trigrams, so this is "word >= 5 chars".
+#
+# about_gram is the LAST unbounded matcher: bios have no prefix/fuzzy path, so
+# this AND-of-trigrams is the only partial-word route into `about`. At one or two
+# trigrams it degenerates into a bare substring test with no bound at all —
+# measured, `about_gram contains "ode"` matched "model", "code" and a bio reading
+# "hosted by ODELL", none within any typo budget of "ode". At 3+ AND'ed trigrams
+# it is selective enough to be worth its recall.
+#
+# Short queries still reach bios through the exact-token clause on `about`.
+_MIN_ABOUT_GRAMS = 3
+
+
 def _about_gram_clause_for_word(word: str, gram_size: int = 3) -> str:
-    """AND of one word's trigrams against `about_gram` (discriminative)."""
+    """AND of one word's trigrams against `about_gram`, when there are enough of
+    them to be discriminative (see _MIN_ABOUT_GRAMS)."""
     grams = [
         word[i : i + gram_size]
         for i in range(len(word) - gram_size + 1)
         if word[i : i + gram_size].isalnum()
         and len(word[i : i + gram_size]) == gram_size
     ]
-    if not grams:
+    if len(grams) < _MIN_ABOUT_GRAMS:
         return ""
     return "(" + " and ".join(f'about_gram contains "{g}"' for g in grams) + ")"
 
 
+# Hard ceiling on typos, per the team's call (2026-07-30): a hit needing more
+# than this many edits is not matched at all. Vespa's maxEditDistance enforces it
+# at match time, so over-budget docs never enter the candidate set — they are not
+# merely ranked low.
+MAX_TYPO_EDITS = 3
+
+
 def _word_max_edits(word: str) -> int:
-    """Per-word fuzzy budget, length-gated like Meilisearch: <4 → exact/prefix
-    only, ≥4 → 1 edit, ≥9 → 2 edits. See docs §10."""
-    if len(word) >= 9:
-        return 2
-    if len(word) >= 4:
-        return 1
+    """Per-word typo budget, length-gated. Capped at MAX_TYPO_EDITS.
+
+    The gating is the important part: an edit budget is only meaningful as a
+    FRACTION of the word. Measured on a scratch Vespa, 3 edits against the
+    6-letter "odelll" matches "Odessa" — not a typo, a different word. Every tier
+    below holds the ratio near ~22-25%, the same place Meilisearch sits:
+
+        <4     0 edits   any edit on a 3-letter word is a different word
+        4-8    1         25% .. 12%
+        9-12   2         22% .. 17%
+        >=13   3         23% .. less     <- the ceiling, long handles only
+
+    Note this budget does NOT govern prefix matching, which is a different
+    relation: "vitorp" -> "VitorPamplona" appends 7 characters but is not 7
+    typos, it is an unfinished word. Prefix is bounded by _min_prefix_len and by
+    being anchored at the start; see _field_clauses.
+    """
+    n = len(word)
+    if n >= 13:
+        return min(3, MAX_TYPO_EDITS)
+    if n >= 9:
+        return min(2, MAX_TYPO_EDITS)
+    if n >= 4:
+        return min(1, MAX_TYPO_EDITS)
     return 0
 
 
-def _field_clauses(field: str, var: str, max_edits: int, role: str) -> list[str]:
-    """Match clauses for one (field, word): exact, prefix, and up to two fuzzy
-    tiers. Labels depend on the field `role` (§10 / §11)."""
-    def _ann(extra: list[str], label: str | None) -> str:
-        ann = [f'defaultIndex:"{field}"'] + extra
-        if label:
-            ann.append(f'label:"{label}"')
-        return "{" + ",".join(ann) + "}"
+def _field_clauses(field: str, var: str, role: str) -> list[str]:
+    """The exact clause for one (field, word), against the INDEX field via
+    userInput(). This is what feeds matchCount(name)/matchCount(display_name),
+    i.e. doc.sd's exact tier.
 
-    ex_label = {"primary": "mtch_exact", "affiliation": "mtch_affil"}.get(role)
-    pf_label = "mtch_prefix" if role == "primary" else None
-    clauses = [
-        f"({_ann([], ex_label)}userInput({var}))",
-        f"({_ann(['prefix:true'], pf_label)}userInput({var}))",
-    ]
-    # prefixLength:2 — the first two characters must match exactly.
-    if max_edits >= 1:
-        fz1 = "mtch_fz1" if role == "primary" else None
-        clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:1,prefixLength:2}'], fz1)}userInput({var}))"
-        )
-    if max_edits >= 2:
-        fz2 = "mtch_fz2" if role == "primary" else None
-        clauses.append(
-            f"({_ann(['fuzzy:{maxEditDistance:2,prefixLength:2}'], fz2)}userInput({var}))"
-        )
-    return clauses
+    Prefix/fuzzy are NOT emitted here — they are per-word, not per-field, and go
+    to the merged attribute fields via `_near_clauses`.
+    """
+    ann = [f'defaultIndex:"{field}"']
+    label = {"primary": "mtch_exact", "affiliation": "mtch_affil"}.get(role)
+    if label:
+        ann.append(f'label:"{label}"')
+    return ["({" + ",".join(ann) + "}" + f"userInput({var}))"]
+
+
+def _near_clauses(var: str, literal: str) -> list[str]:
+    """Prefix + fuzzy clauses for one word, against the merged attribute fields.
+
+    Emitted ONCE per word (not per source field) because name_parts/name_tokens
+    already merge name + display_name. These feed matchCount(name_parts) /
+    matchCount(name_tokens), i.e. doc.sd's near tier — which is how an exact hit
+    still ranks above a prefix or typo hit.
+
+    Direct terms, never userInput(): userInput() silently drops prefix/fuzzy
+    annotations (see _NEAR_FIELDS).
+    """
+    out: list[str] = []
+    if len(literal) >= _min_prefix_len(literal):
+        for f in _NEAR_FIELDS:
+            out.append(f"({f} contains ({{prefix:true}}{var}))")
+    # prefixLength:2 — the first two characters must match exactly, which also
+    # bounds how much of the attribute dictionary the fuzzy matcher walks.
+    # Only the top budget is emitted: maxEditDistance:N subsumes every smaller N,
+    # so the old per-tier clauses were pure duplicate work once the match_quality
+    # labels they fed turned out to be inert (§11.1).
+    edits = _word_max_edits(literal)
+    if edits:
+        for f in _NEAR_FIELDS:
+            out.append(
+                f"({f} contains ({{maxEditDistance:{edits},prefixLength:2}}fuzzy({var})))"
+            )
+    return out
 
 
 def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
     """All match clauses for one query word across the searchable fields + grams."""
-    me = _word_max_edits(literal)
     clauses: list[str] = []
     for field in _SEARCH_FIELDS:
-        clauses += _field_clauses(field, var, me, _field_role(field))
+        clauses += _field_clauses(field, var, _field_role(field))
+    clauses += _near_clauses(var, literal)
     if with_grams:
-        for gram_field in ("name_gram", "display_name_gram"):
-            gc = _gram_clause(literal, gram_field)
-            if gc:
-                clauses.append(gc)
+        if NAME_GRAM_RECALL:
+            for gram_field in ("name_gram", "display_name_gram"):
+                gc = _gram_clause(literal, gram_field)
+                if gc:
+                    clauses.append(gc)
         agc = _about_gram_clause_for_word(literal)
         if agc:
             clauses.append(agc)

--- a/app/core/vespa_query.py
+++ b/app/core/vespa_query.py
@@ -198,7 +198,7 @@ def _field_clauses(field: str, var: str, role: str) -> list[str]:
     return ["({" + ",".join(ann) + "}" + f"userInput({var}))"]
 
 
-def _near_clauses(var: str, literal: str) -> list[str]:
+def _near_clauses(var: str, literal: str, allow_fuzzy: bool = True) -> list[str]:
     """Prefix + fuzzy clauses for one word, against the merged attribute fields.
 
     Emitted ONCE per word (not per source field) because name_parts/name_tokens
@@ -208,6 +208,8 @@ def _near_clauses(var: str, literal: str) -> list[str]:
 
     Direct terms, never userInput(): userInput() silently drops prefix/fuzzy
     annotations (see _NEAR_FIELDS).
+
+    `allow_fuzzy=False` for the synthetic joined/pair variants — see _word_group.
     """
     out: list[str] = []
     if len(literal) >= _min_prefix_len(literal):
@@ -218,7 +220,7 @@ def _near_clauses(var: str, literal: str) -> list[str]:
     # Only the top budget is emitted: maxEditDistance:N subsumes every smaller N,
     # so the old per-tier clauses were pure duplicate work once the match_quality
     # labels they fed turned out to be inert (§11.1).
-    edits = _word_max_edits(literal)
+    edits = _word_max_edits(literal) if allow_fuzzy else 0
     if edits:
         for f in _NEAR_FIELDS:
             out.append(
@@ -227,13 +229,27 @@ def _near_clauses(var: str, literal: str) -> list[str]:
     return out
 
 
-def _word_group(var: str, literal: str, with_grams: bool = True) -> str:
-    """All match clauses for one query word across the searchable fields + grams."""
+def _word_group(var: str, literal: str, synthetic: bool = False) -> str:
+    """All match clauses for one query word.
+
+    `synthetic=True` marks the joined / adjacent-pair CONCATENATIONS built in
+    build_query, not words the user typed. They get exact + prefix but NO fuzzy
+    and no trigrams:
+
+      * fuzzy — "satoshi nakamoto bitcoin" builds "satoshinakamotobitcoin", 22
+        characters, which draws the TOP typo budget (3 edits). That is the single
+        most expensive matcher we have, walking the attribute dictionary for a
+        token nobody typed, and a 3-word query emitted six of them (joined + 2
+        pairs, x2 fields). Prefix on the concatenation is cheap and does the
+        useful work ("vitorp" -> Vitor Pamplona), so it stays.
+      * trigrams — the concatenation's trigrams are a superset of the words'
+        own, so they add recall noise without adding reach.
+    """
     clauses: list[str] = []
     for field in _SEARCH_FIELDS:
         clauses += _field_clauses(field, var, _field_role(field))
-    clauses += _near_clauses(var, literal)
-    if with_grams:
+    clauses += _near_clauses(var, literal, allow_fuzzy=not synthetic)
+    if not synthetic:
         if NAME_GRAM_RECALL:
             for gram_field in ("name_gram", "display_name_gram"):
                 gc = _gram_clause(literal, gram_field)
@@ -250,9 +266,9 @@ def _build_yql(words: list[str], joined, pairs: list[str]) -> str:
     adjacent-pair concatenations for >2-word queries."""
     parts = [_word_group(f"@w{i}", w) for i, w in enumerate(words[:MAX_QUERY_WORDS])]
     if joined:
-        parts.append(_word_group("@wj", joined, with_grams=False))
+        parts.append(_word_group("@wj", joined, synthetic=True))
     for i, _ in enumerate(pairs):
-        parts.append(_word_group(f"@wp{i}", pairs[i], with_grams=False))
+        parts.append(_word_group(f"@wp{i}", pairs[i], synthetic=True))
     return f"select * from doc where {' or '.join(parts)}"
 
 

--- a/tests/test_vespa_query.py
+++ b/tests/test_vespa_query.py
@@ -23,6 +23,7 @@ from app.core.vespa_query import (
     MAX_TYPO_EDITS,
     MIN_PREFIX_LEN,
     NAME_GRAM_RECALL,
+    _NEAR_FIELDS,
     _word_max_edits,
     build_query,
 )
@@ -142,6 +143,26 @@ def test_params_bind_every_referenced_word():
     assert params["w1"] == "pamplona"
     # >=2 words also emit the joined variant
     assert params["wj"] == "vitorpamplona"
+
+
+# ---------------------------------------------------------------------------
+# Cost: the synthetic concatenations must not draw the expensive matcher
+# ---------------------------------------------------------------------------
+def test_synthetic_concatenations_get_prefix_but_not_fuzzy():
+    """build_query() invents a joined variant and adjacent pairs. Nobody typed
+    them, and they are long, so they drew the TOP typo budget — the most
+    expensive matcher we have, six times over on a 3-word query."""
+    yql = _yql("satoshi nakamoto bitcoin")
+    assert "@wj" in yql and "@wp0" in yql          # the synthetics are still built
+    assert "prefix:true}@wj" in yql                # prefix on them is cheap + useful
+    for var in ("@wj", "@wp0", "@wp1"):
+        assert f"fuzzy({var})" not in yql
+
+
+def test_fuzzy_clause_count_stays_bounded_by_real_words():
+    """One fuzzy clause per (real word over the length floor) per near field."""
+    yql = _yql("satoshi nakamoto bitcoin")
+    assert yql.count("fuzzy(") == 3 * len(_NEAR_FIELDS)
 
 
 def test_word_cap_is_enforced():

--- a/tests/test_vespa_query.py
+++ b/tests/test_vespa_query.py
@@ -1,0 +1,149 @@
+"""What the query builder actually emits.
+
+`vespa_query` decides what search can match, and until now nothing tested it.
+That is not an incidental gap: it is why `({defaultIndex:"name",prefix:true}
+userInput(@w))` shipped for a month as a silent no-op — Vespa accepts the
+annotation, drops it, and returns a plain exact match with no error anywhere. No
+staging check catches a matcher that quietly does nothing; only an assertion on
+the emitted YQL does.
+
+These are pure string assertions (stdlib-only module, no services), so they run
+in the fast suite and pin the two properties that failed silently:
+
+  * prefix/fuzzy are DIRECT terms against the attribute fields, never userInput()
+  * the budget that bounds them is actually applied
+
+See docs/search-vs-tapestry.md §10/§11 and the note above `field name` in the
+chart's vespa-app/schemas/doc.sd.
+"""
+
+import pytest
+
+from app.core.vespa_query import (
+    MAX_TYPO_EDITS,
+    MIN_PREFIX_LEN,
+    NAME_GRAM_RECALL,
+    _word_max_edits,
+    build_query,
+)
+
+
+def _yql(text: str) -> str:
+    return build_query(text)[1]
+
+
+# ---------------------------------------------------------------------------
+# The regression this file exists for
+# ---------------------------------------------------------------------------
+def test_prefix_is_a_direct_term_not_userinput():
+    """The original bug: a prefix annotation on userInput() is silently dropped.
+
+    Asserting the *shape* is the point — a test that only checked "does a prefix
+    clause exist" would have passed throughout the outage.
+    """
+    yql = _yql("odell")
+    assert 'name_parts contains ({prefix:true}@w0)' in yql
+    assert 'name_tokens contains ({prefix:true}@w0)' in yql
+    # The form that parses, runs, and does nothing.
+    assert "prefix:true}userInput" not in yql
+
+
+def test_fuzzy_is_a_direct_term_not_userinput():
+    yql = _yql("odelling")
+    assert "name_parts contains ({maxEditDistance:1,prefixLength:2}fuzzy(@w0))" in yql
+    assert "fuzzy:{maxEditDistance" not in yql
+
+
+def test_prefix_and_fuzzy_never_target_index_only_fields():
+    """about/website/nip05/lud16 have no attribute sibling. A prefix or fuzzy
+    term against them is an ERROR (HTTP 400), not a no-op."""
+    yql = _yql("something")
+    for field in ("about", "website", "nip05", "lud16", "name", "display_name"):
+        assert f"{field} contains ({{prefix:true}}" not in yql
+        assert f"{field} contains ({{maxEditDistance" not in yql
+
+
+# ---------------------------------------------------------------------------
+# Bounds: every match must be within a stated distance of the query
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "word,expected",
+    [("ab", 0), ("ode", 0), ("odel", 1), ("odelling", 1), ("odellington", 2),
+     ("odellingtonshire", 3)],
+)
+def test_typo_budget_ladder(word, expected):
+    assert _word_max_edits(word) == expected
+
+
+def test_typo_budget_never_exceeds_the_ceiling():
+    long_word = "a" * 60
+    assert _word_max_edits(long_word) <= MAX_TYPO_EDITS
+
+
+def test_only_the_top_edit_distance_is_emitted():
+    """maxEditDistance:N subsumes every smaller N — emitting a clause per tier is
+    duplicate matching work."""
+    yql = _yql("odellington")  # 2-edit budget
+    assert "maxEditDistance:2" in yql
+    assert "maxEditDistance:1" not in yql
+
+
+def test_short_words_get_no_fuzzy_clause():
+    yql = _yql("ode")
+    assert "fuzzy(" not in yql
+
+
+def test_prefix_floor_applies_to_latin():
+    assert "prefix:true" not in _yql("od")
+    assert "prefix:true" in _yql("ode")
+    assert MIN_PREFIX_LEN == 3
+
+
+def test_prefix_floor_is_lower_for_non_ascii():
+    """A 2-character CJK query is as specific as a 5-6 character Latin one; the
+    Latin floor made such names unreachable."""
+    assert "prefix:true" in _yql("中村")
+
+
+def test_name_trigram_recall_is_off():
+    """The one matcher with no bound on how different a hit could be: a trigram
+    OR matched anything sharing 3 characters, so "ode" pulled in "model"."""
+    assert NAME_GRAM_RECALL is False
+    yql = _yql("ode")
+    assert "name_gram contains" not in yql
+    assert "display_name_gram contains" not in yql
+
+
+def test_about_trigrams_need_enough_grams_to_discriminate():
+    """about_gram is the bio-side equivalent. At one or two trigrams the AND
+    degenerates into a bare substring test — "ode" reached a bio reading
+    "hosted by ODELL"."""
+    assert "about_gram contains" not in _yql("ode")
+    assert "about_gram contains" not in _yql("odel")
+    assert "about_gram contains" in _yql("odell")
+
+
+# ---------------------------------------------------------------------------
+# Shape that the rest of the pipeline depends on
+# ---------------------------------------------------------------------------
+def test_exact_clause_still_targets_the_index_fields():
+    """matchCount(name)/matchCount(display_name) drive doc.sd's exact tier, so
+    the exact clause must keep using userInput() against the INDEX fields."""
+    yql = _yql("odell")
+    assert '{defaultIndex:"name",label:"mtch_exact"}userInput(@w0)' in yql
+    assert '{defaultIndex:"display_name",label:"mtch_exact"}userInput(@w0)' in yql
+
+
+def test_params_bind_every_referenced_word():
+    words, yql, params = build_query("vitor pamplona")
+    for var in params:
+        assert f"@{var}" in yql
+    assert params["w0"] == "vitor"
+    assert params["w1"] == "pamplona"
+    # >=2 words also emit the joined variant
+    assert params["wj"] == "vitorpamplona"
+
+
+def test_word_cap_is_enforced():
+    words, yql, params = build_query(" ".join(f"w{i}" for i in range(20)))
+    assert len(words) <= 6


### PR DESCRIPTION
## 🚫 Do not merge before NosFabrica/brainstorm-k8s#3

**Draft on purpose.** This is the second half of a two-repo change and merging it first is an **outage**, not a degraded result:

```
this branch + current schema
  ->  HTTP 400: Could not create query from YQL: Field 'name_parts' does not exist.
```

Every search request, immediately. Required order:

1. Merge **NosFabrica/brainstorm-k8s#3** and deploy the chart — it adds the `name_parts` / `name_tokens` attribute fields.
2. **Trigger the Vespa reindex** (recipe in that repo's `VESPA.md`). The new fields are empty on every existing document until this runs, and the reindex request only *starts* on the next package activation.
3. **Then** merge this and deploy.

Undrafting is step 3's cue.

---

## The bug

"Ode" could not find "ODELL". "Odel" returned **nothing at all**. "VitorP" missed "Vitor Pamplona" while "VitorPa" found it — adding a letter made results vanish and adding another brought them back.

Root-caused against a real Vespa (`vespaengine/vespa` in Docker) rather than from documentation. There were **two independent causes, and each masked the other**:

1. **`userInput()` does not propagate `prefix` / `fuzzy` term annotations.** The clause this file has emitted for months — `({defaultIndex:"name",prefix:true}userInput(@w))` — parses, runs, and silently behaves as a plain exact match. Nothing ever errored, which is why no one caught it.
2. **Both matchers require an ATTRIBUTE field.** Against an `index` field the direct form is rejected outright (`'name' is not an attribute field: Prefix matching is not supported`; `fuzzy()` returns HTTP 400).

Cause 1 turned cause 2 into a no-op. Fixing either alone changes nothing. Search has effectively been **exact-whole-token-only**, with the `*_gram` trigram fields as the sole fallback for everything else — which is also where the junk was coming from.

## Changes

### `app/core/vespa_query.py`

- **Prefix/fuzzy become direct terms** against `name_parts` / `name_tokens`. Two granularities, both load-bearing: `name_parts` splits at every word start (camelCase + non-alphanumeric) so "meme" finds "BitcoinMemeTreasury"; `name_tokens` keeps whole tokens, because `name_parts` **alone regresses** "vitorp" → "VitorPamplona" (it splits to `[vitor, pamplona]`, and "vitorp" prefixes neither).
- **`MAX_TYPO_EDITS = 3`** with a length-gated ladder (`<4`: 0, `4-8`: 1, `9-12`: 2, `>=13`: 3). Enforced by Vespa's `maxEditDistance` at *match* time, so an over-budget document never enters the candidate set — it is not merely ranked low. The gating is the important part: 3 edits against the 6-letter "odelll" matches **"Odessa"**, which is a different word, not a typo.
- **Only the top edit distance is emitted.** `maxEditDistance:N` subsumes every smaller N; the per-tier clauses were duplicate matching work once the `match_quality` labels they fed turned out to be inert (§11.1).
- **`NAME_GRAM_RECALL = False`.** A trigram OR matched any document sharing a single 3-character sequence — `"ode"` pulled in **"model"** and **"code"**, `"odel"` pulled in **"CITADELDISPATCH"**. None are within any edit budget of the query, and no typo cap can constrain a matcher that isn't edit-distance-based. It only existed to paper over prefix/fuzzy being broken.
- **`_MIN_ABOUT_GRAMS = 3`.** The same unbounded behaviour on the bio side: at one or two trigrams the AND degenerates into a bare substring test, which is how "Ode" reached a bio reading "hosted by ODELL". Short queries still reach bios via the exact-token clause on `about`.
- **Script-aware prefix floor** — 3 for Latin, 2 for anything non-ASCII. A flat 3 made 2-character CJK queries ("中村") unreachable, which would have undone the point of the unicode-aware split on the schema side.

### `app/core/vespa.py`

- `_match_tier` gains a **`near`** branch. Without it every prefix/typo hit reports as `"gram"` to the API, the search inspector and `tools/rank_ab.py` — labelled as noise while actually being a real name match. The affiliation branch also now accepts the default profile's `affiliation_match_text` gate.

### `tests/test_vespa_query.py` — new

This module decides what search can match and had **zero test coverage**. That is not incidental: it is the structural reason a silently-inert annotation survived a month. No staging check catches a matcher that quietly does nothing — only an assertion on the emitted YQL does.

19 tests, stdlib-only (no services, runs in the fast suite). They pin the two properties that failed silently — that prefix/fuzzy are direct terms against the attribute fields, and that the budget bounding them is applied.

**Verified they catch the original bug.** Run against the pre-fix builder, all five shape assertions fail:

```
FAIL  prefix is a direct term on name_parts
FAIL  no silent prefix-on-userInput form
FAIL  fuzzy is a direct term
FAIL  no silent fuzzy-annotation form
FAIL  name trigram recall is off
```

## Measured before / after

Scratch Vespa, schema and query builder together, same corpus:

| query | before | after |
|---|---|---|
| `Ode` | `Ode`, `code`[gram], `model`[gram] | `Ode`, `ODELL`[near], `Odessa`[near] |
| `Odel` | **zero results** | `ODELL`[near], `Ode`[near] |
| `Odelll` | `ODELL`[gram] | `ODELL`[near] |
| `VitorP` | `VitorPamplona`[gram] | `VitorPamplona`[near] |
| `meme` | **zero results** | `BitcoinMemeTreasury`[near] |
| `lover` | `CoffeeLover`[gram] | `CoffeeLover`[near] |
| `Odell` | unchanged | unchanged (no regression) |

Worst edit distance of any returned hit, across name / display_name / about / website: **1** (budget is 3, so the bound is not close to binding).

Non-Latin names verified unaffected or improved — "влад", "иванов", "中村", "josé".

## Trade-off to be aware of

Turning off name-side trigram recall **drops infix matching**: "dell" no longer finds "ODELL". Prefix is anchored at the start and fuzzy keeps `prefixLength:2`. That is the price of every hit being within a stated edit distance — you cannot have an unbounded matcher and a bound at the same time. `NAME_GRAM_RECALL` is a single flag if the recall is worth more than the bound; the `name_gram` fields remain in the schema either way.

## Verification status

Everything above was verified against a real Vespa, but on a **16-document corpus**. The matcher semantics are corpus-independent and confirmed. Fuzzy latency across ~3.3M profiles is **not** — worth watching query timings after the staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrgWQMKzXYks7JiMgorK5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrgWQMKzXYks7JiMgorK5u)_